### PR TITLE
Input 345 for performance tests

### DIFF
--- a/TestSuite/inputs/descriptions.txt
+++ b/TestSuite/inputs/descriptions.txt
@@ -156,6 +156,10 @@ Page* where more or less this feature is used: 2230
 250) MultiTargeting
 320) Fe-based Superconductors model on a chain
 340) A test of the Fe-based Superconductors extended model
+341) Performance input: two-orbital Hubbard 8 sites
+342) Performance input: two-orbital Hubbard 16 sites; m=200, 500
+343) Performance input: two-orbital Hubbard 32 sites; m=1000, 1000
+344) Performance input: two-orbital Hubbard 16 sites; m=1000, 1000
 ###TD 350) Transverse-Field Ising MultiOrb (Using Heisenberg, benchmark)
 ###TD 351) Transverse-Field Ising MultiOrb 1
 ###TD 352) Transverse-Field Ising MultiOrb 2

--- a/TestSuite/inputs/descriptions.txt
+++ b/TestSuite/inputs/descriptions.txt
@@ -161,6 +161,10 @@ Page* where more or less this feature is used: 2230
 250) MultiTargeting
 320) Fe-based Superconductors model on a chain
 340) A test of the Fe-based Superconductors extended model
+341) Performance input: two-orbital Hubbard 8 sites
+342) Performance input: two-orbital Hubbard 16 sites; m=200, 500
+343) Performance input: two-orbital Hubbard 32 sites; m=1000, 1000
+344) Performance input: two-orbital Hubbard 16 sites; m=1000, 1000
 ###TD 350) Transverse-Field Ising MultiOrb (Using Heisenberg, benchmark)
 ###TD 351) Transverse-Field Ising MultiOrb 1
 ###TD 352) Transverse-Field Ising MultiOrb 2

--- a/TestSuite/inputs/input345.ain
+++ b/TestSuite/inputs/input345.ain
@@ -1,0 +1,59 @@
+##Ainur1.0
+
+TotalNumberOfSites=16;
+NumberOfTerms=3;
+
+gt0:DegreesOfFreedom=2;
+gt0:GeometryKind=ladderx;
+gt0:GeometryOptions=ConstantValues;
+gt0:LadderLeg=2;
+gt0:dir0:Connectors=[
+[-0.058, 0],
+[0, -0.2196]];
+
+gt0:dir1:Connectors=[
+[-0.2196, 0],
+[0, -0.058]];
+
+gt0:dir2:Connectors=[
+[0.20828, 0.079],
+[0.079, 0.20828]];
+
+gt0:dir3:Connectors=[
+[0.20828, -0.079],
+[-0.079, 0.20828]];
+
+gt1:DegreesOfFreedom=1;
+gt1:GeometryKind=ladderx;
+gt1:GeometryOptions=ConstantValues;
+gt1:LadderLeg=2;
+gt1:dir0:Connectors= [0.1];
+gt1:dir1:Connectors= [0.1];
+gt1:dir2:Connectors= [0.02];
+gt1:dir3:Connectors= [0.02];
+
+gt2:DegreesOfFreedom=1;
+gt2:GeometryKind=ladderx;
+gt2:GeometryOptions=ConstantValues;
+gt2:LadderLeg=2;
+gt2:dir0:Connectors= [0.1];
+gt2:dir1:Connectors= [0.1];
+gt2:dir2:Connectors= [0.02];
+gt2:dir3:Connectors= [0.02];
+
+hubbardU=[4.,...x4];
+# The syntax below implies 32 zeroes for the vector
+potentialV=[0.,...x64];
+Model=FeAsBasedScExtended;
+FeAsMode=INT_PAPER33;
+Orbitals=2;
+SolverOptions=twositedmrg,minimizedisk;
+Version=61289987cdd32b8485213ac0415baf4e9cd16432;
+OutputFile=data345;
+InfiniteLoopKeptStates=20;
+FiniteLoops=[
+	[@auto, 1000, 0],
+	[@auto, 1000, 0]];
+TargetElectronsUp=15;
+TargetElectronsDown=15;
+


### PR DESCRIPTION
@masterleinad : I think input345.ain in TestSuite/inputs would be the right choice to try to fill the GPU: 16 sites so it doesn't run so slow; but m=1000 so matrices will grow. Would you please test to see how much VRAM it consumes?
During run or after you do for CPU RAM:
```
grep virtual runForinput345.cout
```
