### PR TITLE
VectorWithOffsets PR Series: Part I

### DIFF
--- a/dmrg/Engine/VectorWithOffsets.h
+++ b/dmrg/Engine/VectorWithOffsets.h
@@ -72,11 +72,7 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 /*@{*/
 
 /*! \file VectorWithOffsets.h
- *
- *  A class to represent a vector like this 000000 XXXXXXXX 0000XXXXXXX000000000....
- *  offsets_ is where the first X (non-zero element) is in each block of Xs.
- *  data_ contains a vector of vectors for each nonzero part.
- *  size_ is the size of the whole vector
+ * \brief Defines a vector stored as multiple symmetry-sector blocks.
  */
 #ifndef VECTOR_WITH_OFFSETS_H
 #define VECTOR_WITH_OFFSETS_H
@@ -89,6 +85,17 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 // FIXME: a more generic solution is needed instead of tying
 // the non-zero structure to basis
 namespace Dmrg {
+
+/*!
+ * \brief Stores a vector as independently addressable symmetry-sector blocks.
+ *
+ * The full vector is represented by one data block per basis sector. Only populated
+ * sectors are listed in nzMsAndQns_; offsets_ maps each sector to its position in the
+ * full vector, and index2Sector_ provides the inverse mapping for element access.
+ *
+ * \tparam ComplexOrRealType Scalar type stored by the vector.
+ * \tparam QnType_ Quantum-number type associated with each populated sector.
+ */
 template <typename ComplexOrRealType, typename QnType_> class VectorWithOffsets {
 
 	using ThisType       = VectorWithOffsets<ComplexOrRealType, QnType_>;
@@ -106,12 +113,23 @@ public:
 	using VectorType       = typename PsimagLite::Vector<ComplexOrRealType>::Type;
 	using VectorVectorType = typename PsimagLite::Vector<VectorType>::Type;
 
+	/*!
+	 * \brief CONSTRUCTOR
+	 *
+	 * Constructs an empty vector with no populated sectors.
+	 */
 	VectorWithOffsets()
 	    : progress_("VectorWithOffsets")
 	    , size_(0)
 	    , index2Sector_(0)
 	{ }
 
+	/*!
+	 * \brief Constructs sector storage from one weight per basis sector.
+	 *
+	 * \param[in] weights Number of stored elements in each sector.
+	 * \param[in] someBasis Basis supplying partitions and quantum numbers.
+	 */
 	template <typename SomeBasisType>
 	VectorWithOffsets(const typename PsimagLite::Vector<SizeType>::Type& weights,
 	                  const SomeBasisType&                               someBasis)
@@ -135,6 +153,11 @@ public:
 		setIndex2Sector();
 	}
 
+	/*!
+	 * \brief Rejects the single-sector construction path.
+	 *
+	 * This overload exists for interface compatibility but always reports a fatal error.
+	 */
 	template <typename SomeBasisType>
 	VectorWithOffsets(SizeType, SizeType, const SomeBasisType&)
 	    : progress_("VectorWithOffset")
@@ -142,6 +165,13 @@ public:
 		err("VectorWithOffsets::ctor() FATAL: wrong execution path!\n");
 	}
 
+	/*!
+	 * \brief Constructs storage for an explicit list of populated sectors.
+	 *
+	 * \param[in] compactedWeights Number of stored elements for each listed sector.
+	 * \param[in] sectors Basis-sector index for each compacted weight.
+	 * \param[in] someBasis Basis supplying partitions and quantum numbers.
+	 */
 	template <typename SomeBasisType>
 	VectorWithOffsets(const VectorSizeType& compactedWeights,
 	                  const VectorSizeType& sectors,
@@ -170,6 +200,7 @@ public:
 		setIndex2Sector();
 	}
 
+	/*! \brief Resets the object to an empty vector with no sectors. */
 	void clear()
 	{
 		size_ = 0;
@@ -179,6 +210,15 @@ public:
 		nzMsAndQns_.clear();
 	}
 
+	/*!
+	 * \brief Replaces the vector with data from one sector.
+	 *
+	 * The data are swapped into this object, leaving \p v empty.
+	 *
+	 * \param[in,out] v Sector data transferred into this object.
+	 * \param[in] sector Basis-sector index for the data.
+	 * \param[in] someBasis Basis supplying partitions and quantum numbers.
+	 */
 	template <typename SomeBasisType>
 	void set(VectorType& v, SizeType sector, const SomeBasisType& someBasis)
 	{
@@ -200,6 +240,10 @@ public:
 		setIndex2Sector();
 	}
 
+	/*!
+	 * \brief Allocates zero-filled storage for every basis sector.
+	 * \param[in] someBasis Basis defining the sectors.
+	 */
 	template <typename SomeBasisType> void populateSectors(const SomeBasisType& someBasis)
 	{
 		SizeType np = someBasis.partition() - 1;
@@ -225,6 +269,12 @@ public:
 		progress_.printline(msgg, std::cout);
 	}
 
+	/*!
+	 * \brief Allocates zero-filled sectors matching another vector's quantum numbers.
+	 *
+	 * \param[in] v Vector whose populated quantum numbers are replicated.
+	 * \param[in] someBasis Destination basis used to locate matching sectors.
+	 */
 	template <typename SomeBasisType>
 	void populateFromQns(const VectorWithOffsets& v, const SomeBasisType& someBasis)
 	{
@@ -257,6 +307,11 @@ public:
 		progress_.printline(msgg, std::cout);
 	}
 
+	/*!
+	 * \brief Removes sectors whose stored elements are numerically zero.
+	 *
+	 * All basis sectors must be represented before this operation is called.
+	 */
 	void collapseSectors()
 	{
 		SizeType np = data_.size();
@@ -284,6 +339,11 @@ public:
 		progress_.printline(msgg, std::cout);
 	}
 
+	/*!
+	 * \brief Replaces the data at a basis-sector index.
+	 * \param[in] v Replacement data.
+	 * \param[in] i0 Basis-sector index in the sector array.
+	 */
 	void setDataInSector(const VectorType& v, SizeType i0)
 	{
 		if (i0 >= data_.size())
@@ -292,20 +352,37 @@ public:
 		data_[i0] = v;
 	}
 
+	/*! \brief Returns the number of populated sectors. */
 	SizeType sectors() const { return nzMsAndQns_.size(); }
 
+	/*!
+	 * \brief Returns the basis-sector index of a populated sector.
+	 * \param[in] i Index in the compact list of populated sectors.
+	 */
 	SizeType sector(SizeType i) const
 	{
 		assert(i < nzMsAndQns_.size());
 		return nzMsAndQns_[i].first;
 	}
 
+	/*!
+	 * \brief Returns the quantum number of a populated sector.
+	 * \param[in] i Index in the compact list of populated sectors.
+	 */
 	const QnType& qn(SizeType i) const
 	{
 		assert(i < nzMsAndQns_.size());
 		return nzMsAndQns_[i].second;
 	}
 
+	/*!
+	 * \brief Builds the sector representation from a full vector.
+	 *
+	 * Only sectors containing nonzero elements are stored as populated.
+	 *
+	 * \param[in] v Full vector in basis order.
+	 * \param[in] someBasis Basis defining sector boundaries and quantum numbers.
+	 */
 	template <typename SomeBasisType>
 	void fromFull(const VectorType& v, const SomeBasisType& someBasis)
 	{
@@ -334,6 +411,11 @@ public:
 		setIndex2Sector();
 	}
 
+	/*!
+	 * \brief Copies the data stored at a basis-sector index.
+	 * \param[out] v Receives the sector data.
+	 * \param[in] i Basis-sector index.
+	 */
 	void extract(VectorType& v, SizeType i) const
 	{
 		if (i >= data_.size())
@@ -342,8 +424,13 @@ public:
 		v = data_[i];
 	}
 
+	/*! \brief Returns the size of the corresponding full vector. */
 	SizeType size() const { return size_; }
 
+	/*!
+	 * \brief Returns the number of stored elements at a basis-sector index.
+	 * \param[in] i Basis-sector index.
+	 */
 	SizeType effectiveSize(SizeType i) const
 	{
 		if (i >= data_.size())
@@ -352,6 +439,10 @@ public:
 		return data_[i].size();
 	}
 
+	/*!
+	 * \brief Returns a sector's starting position in the full vector.
+	 * \param[in] i Basis-sector index.
+	 */
 	SizeType offset(SizeType i) const
 	{
 		if (i >= offsets_.size())
@@ -359,6 +450,11 @@ public:
 		return offsets_[i];
 	}
 
+	/*!
+	 * \brief Returns a const reference to an element using sector-local indices.
+	 * \param[in] i Basis-sector index.
+	 * \param[in] j Element index within the sector.
+	 */
 	const ComplexOrRealType& fastAccess(SizeType i, SizeType j) const
 	{
 		assert(i < data_.size());
@@ -366,6 +462,11 @@ public:
 		return data_[i][j];
 	}
 
+	/*!
+	 * \brief Returns a mutable reference to an element using sector-local indices.
+	 * \param[in] i Basis-sector index.
+	 * \param[in] j Element index within the sector.
+	 */
 	ComplexOrRealType& fastAccess(SizeType i, SizeType j)
 	{
 		assert(i < data_.size());
@@ -373,6 +474,12 @@ public:
 		return data_[i][j];
 	}
 
+	/*!
+	 * \brief Returns an element using its full-vector index.
+	 *
+	 * Returns a reference to zero when the index belongs to an unpopulated sector.
+	 * \param[in] i Full-vector index.
+	 */
 	const ComplexOrRealType& slowAccess(SizeType i) const
 	{
 		assert(i < index2Sector_.size());
@@ -382,6 +489,10 @@ public:
 		return data_[j][i - offsets_[j]];
 	}
 
+	/*!
+	 * \brief Returns a mutable element reference using its full-vector index.
+	 * \param[in] i Full-vector index.
+	 */
 	ComplexOrRealType& slowAccess(SizeType i)
 	{
 		int j = index2Sector_[i];
@@ -396,6 +507,10 @@ public:
 		return data_[j][i - offsets_[j]];
 	}
 
+	/*!
+	 * \brief Copies populated sector data into a full sparse-vector representation.
+	 * \param[out] sv Destination sparse vector, resized to size().
+	 */
 	template <typename SparseVectorType> void toSparse(SparseVectorType& sv) const
 	{
 		sv.resize(size_);
@@ -407,6 +522,11 @@ public:
 		}
 	}
 
+	/*!
+	 * \brief Reads the vector from hierarchical storage.
+	 * \param[in,out] io Input object.
+	 * \param[in] label Storage path containing the vector.
+	 */
 	template <typename SomeInputType> void read(SomeInputType& io, PsimagLite::String label)
 	{
 		io.read(size_, label + "/size_");
@@ -439,6 +559,11 @@ public:
 		}
 	}
 
+	/*!
+	 * \brief Writes the vector to hierarchical storage.
+	 * \param[in,out] io Output object.
+	 * \param[in] label Storage path for the vector.
+	 */
 	template <typename SomeIoOutputType>
 	void write(SomeIoOutputType& io, const PsimagLite::String& label) const
 	{
@@ -453,6 +578,12 @@ public:
 	// We don't have a partitioned basis because we don't
 	// have the superblock basis at this point
 	// Therefore, partitioning is bogus here
+	/*!
+	 * \brief Loads a legacy text representation containing populated sectors.
+	 * \param[in,out] io Input object.
+	 * \param[in] label Label advanced to before reading.
+	 * \param[in] counter Occurrence of \p label to load.
+	 */
 	template <typename IoInputter>
 	void loadOneSector(IoInputter& io, const PsimagLite::String& label, SizeType counter = 0)
 	{
@@ -493,6 +624,11 @@ public:
 		setIndex2Sector();
 	}
 
+	/*!
+	 * \brief Scales every populated sector in place.
+	 * \param[in] value Scalar multiplier.
+	 * \return This vector after scaling.
+	 */
 	VectorWithOffsets& operator*=(const ComplexOrRealType& value)
 	{
 		for (SizeType ii = 0; ii < nzMsAndQns_.size(); ++ii) {
@@ -504,6 +640,11 @@ public:
 		return *this;
 	}
 
+	/*!
+	 * \brief Adds another vector's populated sector data in place.
+	 * \param[in] v Vector to add.
+	 * \return This vector after addition.
+	 */
 	VectorWithOffsets operator+=(const VectorWithOffsets& v)
 	{
 		if (nzMsAndQns_.size() == 0) {
@@ -525,14 +666,24 @@ public:
 		return *this;
 	}
 
+	/*!
+	 * \brief Maps a full-vector index to its basis-sector index.
+	 * \param[in] i Full-vector index.
+	 * \return Basis-sector index, or -1 for an unpopulated sector.
+	 */
 	int index2Sector(SizeType i) const
 	{
 		assert(i < index2Sector_.size());
 		return index2Sector_[i];
 	}
 
+	/*! \brief Returns the serialization name for this vector type. */
 	static PsimagLite::String name() { return "vectorwithoffsets"; }
 
+	/*!
+	 * \brief Computes the Euclidean norm across all populated sectors.
+	 * \param[in] v Vector to measure.
+	 */
 	friend RealType norm(const VectorWithOffsets& v)
 	{
 		RealType sum = 0;
@@ -546,6 +697,10 @@ public:
 		return sqrt(sum);
 	}
 
+	/*!
+	 * \brief Normalizes a vector in place.
+	 * \param[in,out] v Vector to normalize.
+	 */
 	friend void normalize(VectorWithOffsets& v)
 	{
 		RealType norma = norm(v);
@@ -561,6 +716,11 @@ public:
 				v.data_[i][j] /= norma;
 	}
 
+	/*!
+	 * \brief Computes the inner product over sectors populated in both vectors.
+	 * \param[in] v1 Left vector.
+	 * \param[in] v2 Right vector.
+	 */
 	friend ComplexOrRealType operator*(const VectorWithOffsets& v1, const VectorWithOffsets& v2)
 	{
 		ComplexOrRealType sum = 0;
@@ -579,6 +739,11 @@ public:
 		return sum;
 	}
 
+	/*!
+	 * \brief Returns a scaled copy of a vector.
+	 * \param[in] value Scalar multiplier.
+	 * \param[in] v Vector to scale.
+	 */
 	friend VectorWithOffsets operator*(const ComplexOrRealType& value,
 	                                   const VectorWithOffsets& v)
 	{
@@ -593,6 +758,11 @@ public:
 		return w;
 	}
 
+	/*!
+	 * \brief Returns the sum of vectors with matching populated sectors.
+	 * \param[in] v1 Left vector.
+	 * \param[in] v2 Right vector.
+	 */
 	friend VectorWithOffsets operator+(const VectorWithOffsets& v1, const VectorWithOffsets& v2)
 	{
 		PsimagLite::String s = "VectorWithOffsets + VectorWithOffsets failed\n";

--- a/dmrg/Engine/tests/CMakeLists.txt
+++ b/dmrg/Engine/tests/CMakeLists.txt
@@ -9,6 +9,12 @@ target_include_directories(testVectorWithOffset PRIVATE ${CMAKE_SOURCE_DIR}/dmrg
                                                         ${CMAKE_SOURCE_DIR}/dmrg/Engine)
 catch_discover_tests(testVectorWithOffset)
 
+add_executable(testVectorWithOffsets testVectorWithOffsets.cpp)
+target_link_libraries(testVectorWithOffsets PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)
+target_include_directories(testVectorWithOffsets PRIVATE ${CMAKE_SOURCE_DIR}/dmrg
+                                                         ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+catch_discover_tests(testVectorWithOffsets)
+
 # BatchedGemm test
 add_executable(test_BatchedGemm test_BatchedGemm.cpp)
 target_link_libraries(test_BatchedGemm PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)

--- a/dmrg/Engine/tests/CMakeLists.txt
+++ b/dmrg/Engine/tests/CMakeLists.txt
@@ -3,6 +3,12 @@ target_link_libraries(test_LastKrylovSlots PRIVATE Catch2::Catch2WithMain psimag
 target_include_directories(test_LastKrylovSlots PRIVATE ${CMAKE_SOURCE_DIR}/dmrg/Engine)
 catch_discover_tests(test_LastKrylovSlots)
 
+add_executable(testVectorWithOffset testVectorWithOffset.cpp)
+target_link_libraries(testVectorWithOffset PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)
+target_include_directories(testVectorWithOffset PRIVATE ${CMAKE_SOURCE_DIR}/dmrg
+                                                        ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+catch_discover_tests(testVectorWithOffset)
+
 # BatchedGemm test
 add_executable(test_BatchedGemm test_BatchedGemm.cpp)
 target_link_libraries(test_BatchedGemm PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)

--- a/dmrg/Engine/tests/CMakeLists.txt
+++ b/dmrg/Engine/tests/CMakeLists.txt
@@ -5,14 +5,12 @@ catch_discover_tests(test_LastKrylovSlots)
 
 add_executable(testVectorWithOffset testVectorWithOffset.cpp)
 target_link_libraries(testVectorWithOffset PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)
-target_include_directories(testVectorWithOffset PRIVATE ${CMAKE_SOURCE_DIR}/dmrg
-                                                        ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+target_include_directories(testVectorWithOffset PRIVATE ${CMAKE_SOURCE_DIR}/dmrg ${CMAKE_SOURCE_DIR}/dmrg/Engine)
 catch_discover_tests(testVectorWithOffset)
 
 add_executable(testVectorWithOffsets testVectorWithOffsets.cpp)
 target_link_libraries(testVectorWithOffsets PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)
-target_include_directories(testVectorWithOffsets PRIVATE ${CMAKE_SOURCE_DIR}/dmrg
-                                                         ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+target_include_directories(testVectorWithOffsets PRIVATE ${CMAKE_SOURCE_DIR}/dmrg ${CMAKE_SOURCE_DIR}/dmrg/Engine)
 catch_discover_tests(testVectorWithOffsets)
 
 # BatchedGemm test

--- a/dmrg/Engine/tests/testVectorWithOffset.cpp
+++ b/dmrg/Engine/tests/testVectorWithOffset.cpp
@@ -1,15 +1,15 @@
 #include "Qn.h"
 #include "VectorWithOffset.h"
-#include <PsimagLite/Vector.h>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <complex>
 #include <map>
+#include <vector>
 
 namespace {
 
-using VectorSizeType = PsimagLite::Vector<SizeType>::Type;
+using VectorSizeType = std::vector<SizeType>;
 
 template <typename T> void checkValue(const T& actual, double real, double imag = 0.0)
 {
@@ -43,15 +43,15 @@ public:
 
 private:
 
-	VectorSizeType         partitions_;
-	Dmrg::Qn::VectorQnType qns_;
+	VectorSizeType        partitions_;
+	std::vector<Dmrg::Qn> qns_;
 };
 
 template <typename T> class FakeIo {
 
 public:
 
-	using VectorType           = typename PsimagLite::Vector<T>::Type;
+	using VectorType           = std::vector<T>;
 	using VectorWithOffsetType = Dmrg::VectorWithOffset<T, Dmrg::Qn>;
 	using PairQnType           = typename VectorWithOffsetType::PairQnType;
 
@@ -151,7 +151,7 @@ TEMPLATE_TEST_CASE("VectorWithOffset sets, extracts, and clears data",
                    double,
                    std::complex<double>)
 {
-	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType           = std::vector<TestType>;
 	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           data({ 1.0, 2.0, 3.0 });
@@ -189,7 +189,7 @@ TEMPLATE_TEST_CASE("VectorWithOffset converts from a full vector",
                    double,
                    std::complex<double>)
 {
-	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType           = std::vector<TestType>;
 	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorWithOffsetType v;
@@ -213,7 +213,7 @@ TEMPLATE_TEST_CASE("VectorWithOffset public arithmetic",
                    double,
                    std::complex<double>)
 {
-	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType           = std::vector<TestType>;
 	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           first({ 3.0, 4.0, 0.0 });
@@ -251,7 +251,7 @@ TEMPLATE_TEST_CASE("VectorWithOffset populates matching quantum-number sector",
                    double,
                    std::complex<double>)
 {
-	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType           = std::vector<TestType>;
 	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           data({ 1.0, 2.0, 3.0 });
@@ -277,7 +277,7 @@ TEMPLATE_TEST_CASE("VectorWithOffset writes and reads its public representation"
                    double,
                    std::complex<double>)
 {
-	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType           = std::vector<TestType>;
 	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           data({ 2.0, 4.0, 6.0 });

--- a/dmrg/Engine/tests/testVectorWithOffset.cpp
+++ b/dmrg/Engine/tests/testVectorWithOffset.cpp
@@ -2,14 +2,20 @@
 #include "VectorWithOffset.h"
 #include <PsimagLite/Vector.h>
 #include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <complex>
 #include <map>
 
 namespace {
 
-using VectorType           = PsimagLite::Vector<double>::Type;
-using VectorSizeType       = PsimagLite::Vector<SizeType>::Type;
-using VectorWithOffsetType = Dmrg::VectorWithOffset<double, Dmrg::Qn>;
+using VectorSizeType = PsimagLite::Vector<SizeType>::Type;
+
+template <typename T> void checkValue(const T& actual, double real, double imag = 0.0)
+{
+	CHECK(std::real(actual) == Catch::Approx(real));
+	CHECK(std::imag(actual) == Catch::Approx(imag));
+}
 
 Dmrg::Qn makeQn(bool odd)
 {
@@ -41,15 +47,19 @@ private:
 	Dmrg::Qn::VectorQnType qns_;
 };
 
-class FakeIo {
+template <typename T> class FakeIo {
 
 public:
+
+	using VectorType           = typename PsimagLite::Vector<T>::Type;
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<T, Dmrg::Qn>;
+	using PairQnType           = typename VectorWithOffsetType::PairQnType;
 
 	void createGroup(const PsimagLite::String& label) { group_ = label; }
 
 	void write(SizeType value, const PsimagLite::String& label) { sizes_[label] = value; }
 
-	void write(const VectorWithOffsetType::PairQnType& value, const PsimagLite::String& label)
+	void write(const PairQnType& value, const PsimagLite::String& label)
 	{
 		pairs_.insert_or_assign(label, value);
 	}
@@ -61,10 +71,7 @@ public:
 
 	void read(SizeType& value, const PsimagLite::String& label) { value = sizes_.at(label); }
 
-	void read(VectorWithOffsetType::PairQnType& value, const PsimagLite::String& label)
-	{
-		value = pairs_.at(label);
-	}
+	void read(PairQnType& value, const PsimagLite::String& label) { value = pairs_.at(label); }
 
 	void read(VectorType& value, const PsimagLite::String& label)
 	{
@@ -75,16 +82,20 @@ public:
 
 private:
 
-	PsimagLite::String                                             group_;
-	std::map<PsimagLite::String, SizeType>                         sizes_;
-	std::map<PsimagLite::String, VectorWithOffsetType::PairQnType> pairs_;
-	std::map<PsimagLite::String, VectorType>                       vectors_;
+	PsimagLite::String                       group_;
+	std::map<PsimagLite::String, SizeType>   sizes_;
+	std::map<PsimagLite::String, PairQnType> pairs_;
+	std::map<PsimagLite::String, VectorType> vectors_;
 };
 
 } // namespace
 
-TEST_CASE("VectorWithOffset default state and metadata", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset default state and metadata",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	VectorWithOffsetType v;
 
 	CHECK(v.size() == 0);
@@ -93,11 +104,15 @@ TEST_CASE("VectorWithOffset default state and metadata", "[VectorWithOffset]")
 	CHECK(v.offset() == 0);
 	CHECK(v.index2Sector(0) == -1);
 	CHECK(VectorWithOffsetType::name() == "vectorwithoffset");
-	CHECK(VectorWithOffsetType::zero_ == 0.0);
+	CHECK(VectorWithOffsetType::zero_ == TestType(0.0));
 }
 
-TEST_CASE("VectorWithOffset constructors expose one sector", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset constructors expose one sector",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis basis;
 
 	SECTION("weight and sector constructor")
@@ -131,8 +146,13 @@ TEST_CASE("VectorWithOffset constructors expose one sector", "[VectorWithOffset]
 	}
 }
 
-TEST_CASE("VectorWithOffset sets, extracts, and clears data", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset sets, extracts, and clears data",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           data({ 1.0, 2.0, 3.0 });
 	VectorWithOffsetType v;
@@ -153,9 +173,9 @@ TEST_CASE("VectorWithOffset sets, extracts, and clears data", "[VectorWithOffset
 	v.extract(extracted, 0);
 	CHECK(extracted == replacement);
 
-	std::vector<double> sparse;
+	std::vector<TestType> sparse;
 	v.toSparse(sparse);
-	CHECK(sparse == std::vector<double>({ 0.0, 0.0, 4.0, 5.0, 6.0 }));
+	CHECK(sparse == std::vector<TestType>({ 0.0, 0.0, 4.0, 5.0, 6.0 }));
 
 	v.clear();
 	CHECK(v.size() == 0);
@@ -164,8 +184,13 @@ TEST_CASE("VectorWithOffset sets, extracts, and clears data", "[VectorWithOffset
 	CHECK(v.offset() == 0);
 }
 
-TEST_CASE("VectorWithOffset converts from a full vector", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset converts from a full vector",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorWithOffsetType v;
 	v.fromFull(VectorType({ 0.0, 0.0, 7.0, 8.0, 9.0 }), basis);
@@ -183,8 +208,13 @@ TEST_CASE("VectorWithOffset converts from a full vector", "[VectorWithOffset]")
 	CHECK(v.index2Sector(5) == -1);
 }
 
-TEST_CASE("VectorWithOffset public arithmetic", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset public arithmetic",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           first({ 3.0, 4.0, 0.0 });
 	VectorWithOffsetType v;
@@ -192,32 +222,37 @@ TEST_CASE("VectorWithOffset public arithmetic", "[VectorWithOffset]")
 
 	CHECK(norm(v) == Catch::Approx(5.0));
 	normalize(v);
-	CHECK(v.fastAccess(0, 0) == Catch::Approx(0.6));
-	CHECK(v.fastAccess(0, 1) == Catch::Approx(0.8));
+	checkValue(v.fastAccess(0, 0), 0.6);
+	checkValue(v.fastAccess(0, 1), 0.8);
 
 	v.fastAccess(0, 2) = 1.0;
 	v.slowAccess(2)    = 1.0;
 	v *= 2.0;
-	CHECK(v.fastAccess(0, 0) == Catch::Approx(2.0));
+	checkValue(v.fastAccess(0, 0), 2.0);
 
 	VectorWithOffsetType scaled = 0.5 * v;
-	CHECK(scaled.fastAccess(0, 0) == Catch::Approx(1.0));
-	CHECK(scaled * scaled == Catch::Approx(2.64));
+	checkValue(scaled.fastAccess(0, 0), 1.0);
+	checkValue(scaled * scaled, 2.64);
 
 	VectorWithOffsetType sum;
 	sum += scaled;
 	sum += scaled;
-	CHECK(sum.fastAccess(0, 0) == Catch::Approx(2.0));
-	CHECK(sum.fastAccess(0, 1) == Catch::Approx(1.6));
-	CHECK(sum.fastAccess(0, 2) == Catch::Approx(2.0));
+	checkValue(sum.fastAccess(0, 0), 2.0);
+	checkValue(sum.fastAccess(0, 1), 1.6);
+	checkValue(sum.fastAccess(0, 2), 2.0);
 
 	VectorWithOffsetType otherSector(2, 0, basis);
-	CHECK(scaled * otherSector == 0.0);
+	CHECK(scaled * otherSector == TestType(0.0));
 	CHECK_THROWS_AS(sum += otherSector, PsimagLite::RuntimeError);
 }
 
-TEST_CASE("VectorWithOffset populates matching quantum-number sector", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset populates matching quantum-number sector",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           data({ 1.0, 2.0, 3.0 });
 	VectorWithOffsetType source;
@@ -237,14 +272,19 @@ TEST_CASE("VectorWithOffset populates matching quantum-number sector", "[VectorW
 	CHECK_THROWS_AS(destination.populateSectors(basis), PsimagLite::RuntimeError);
 }
 
-TEST_CASE("VectorWithOffset writes and reads its public representation", "[VectorWithOffset]")
+TEMPLATE_TEST_CASE("VectorWithOffset writes and reads its public representation",
+                   "[VectorWithOffset]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType           = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetType = Dmrg::VectorWithOffset<TestType, Dmrg::Qn>;
 	const FakeBasis      basis;
 	VectorType           data({ 2.0, 4.0, 6.0 });
 	VectorWithOffsetType original;
 	original.set(data, 1, basis);
 
-	FakeIo io;
+	FakeIo<TestType> io;
 	original.write(io, "vector");
 	CHECK(io.group() == "vector");
 
@@ -254,9 +294,9 @@ TEST_CASE("VectorWithOffset writes and reads its public representation", "[Vecto
 	CHECK(restored.offset() == original.offset());
 	CHECK(restored.sector(0) == original.sector(0));
 	CHECK(restored.qn(0) == original.qn(0));
-	CHECK(restored * original == Catch::Approx(56.0));
+	checkValue(restored * original, 56.0);
 
 	VectorWithOffsetType loaded;
 	loaded.loadOneSector(io, "vector", 7);
-	CHECK(loaded * original == Catch::Approx(56.0));
+	checkValue(loaded * original, 56.0);
 }

--- a/dmrg/Engine/tests/testVectorWithOffset.cpp
+++ b/dmrg/Engine/tests/testVectorWithOffset.cpp
@@ -1,0 +1,262 @@
+#include "Qn.h"
+#include "VectorWithOffset.h"
+#include <PsimagLite/Vector.h>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+
+namespace {
+
+using VectorType           = PsimagLite::Vector<double>::Type;
+using VectorSizeType       = PsimagLite::Vector<SizeType>::Type;
+using VectorWithOffsetType = Dmrg::VectorWithOffset<double, Dmrg::Qn>;
+
+Dmrg::Qn makeQn(bool odd)
+{
+	return Dmrg::Qn(odd, VectorSizeType(), Dmrg::Qn::PairSizeType(0, 0), 0);
+}
+
+class FakeBasis {
+
+public:
+
+	FakeBasis()
+	    : partitions_({ 0, 2, 5 })
+	    , qns_({ makeQn(false), makeQn(true) })
+	{ }
+
+	SizeType size() const { return partitions_.back(); }
+
+	SizeType partition() const { return partitions_.size(); }
+
+	SizeType partition(SizeType sector) const { return partitions_[sector]; }
+
+	const Dmrg::Qn& pseudoQn(SizeType sector) const { return qns_[sector]; }
+
+	const Dmrg::Qn& qnEx(SizeType sector) const { return qns_[sector]; }
+
+private:
+
+	VectorSizeType         partitions_;
+	Dmrg::Qn::VectorQnType qns_;
+};
+
+class FakeIo {
+
+public:
+
+	void createGroup(const PsimagLite::String& label) { group_ = label; }
+
+	void write(SizeType value, const PsimagLite::String& label) { sizes_[label] = value; }
+
+	void write(const VectorWithOffsetType::PairQnType& value, const PsimagLite::String& label)
+	{
+		pairs_.insert_or_assign(label, value);
+	}
+
+	void write(const VectorType& value, const PsimagLite::String& label)
+	{
+		vectors_[label] = value;
+	}
+
+	void read(SizeType& value, const PsimagLite::String& label) { value = sizes_.at(label); }
+
+	void read(VectorWithOffsetType::PairQnType& value, const PsimagLite::String& label)
+	{
+		value = pairs_.at(label);
+	}
+
+	void read(VectorType& value, const PsimagLite::String& label)
+	{
+		value = vectors_.at(label);
+	}
+
+	const PsimagLite::String& group() const { return group_; }
+
+private:
+
+	PsimagLite::String                                             group_;
+	std::map<PsimagLite::String, SizeType>                         sizes_;
+	std::map<PsimagLite::String, VectorWithOffsetType::PairQnType> pairs_;
+	std::map<PsimagLite::String, VectorType>                       vectors_;
+};
+
+} // namespace
+
+TEST_CASE("VectorWithOffset default state and metadata", "[VectorWithOffset]")
+{
+	VectorWithOffsetType v;
+
+	CHECK(v.size() == 0);
+	CHECK(v.sectors() == 0);
+	CHECK(v.effectiveSize() == 0);
+	CHECK(v.offset() == 0);
+	CHECK(v.index2Sector(0) == -1);
+	CHECK(VectorWithOffsetType::name() == "vectorwithoffset");
+	CHECK(VectorWithOffsetType::zero_ == 0.0);
+}
+
+TEST_CASE("VectorWithOffset constructors expose one sector", "[VectorWithOffset]")
+{
+	const FakeBasis basis;
+
+	SECTION("weight and sector constructor")
+	{
+		VectorWithOffsetType v(3, 1, basis);
+		CHECK(v.size() == 5);
+		CHECK(v.sectors() == 1);
+		CHECK(v.sector(0) == 1);
+		CHECK(v.qn(0) == basis.pseudoQn(1));
+		CHECK(v.offset(0) == 2);
+		CHECK(v.effectiveSize(0) == 3);
+	}
+
+	SECTION("compacted weights constructor")
+	{
+		VectorSizeType       weights(1, 2);
+		VectorSizeType       sectors(1, 0);
+		VectorWithOffsetType v(weights, sectors, basis);
+		CHECK(v.size() == 5);
+		CHECK(v.sector(0) == 0);
+		CHECK(v.offset() == 0);
+		CHECK(v.effectiveSize() == 2);
+	}
+
+	SECTION("multiple sectors are rejected")
+	{
+		VectorSizeType weights(2, 1);
+		VectorSizeType sectors(2, 0);
+		CHECK_THROWS_AS(VectorWithOffsetType(weights, sectors, basis),
+		                PsimagLite::RuntimeError);
+	}
+}
+
+TEST_CASE("VectorWithOffset sets, extracts, and clears data", "[VectorWithOffset]")
+{
+	const FakeBasis      basis;
+	VectorType           data({ 1.0, 2.0, 3.0 });
+	VectorWithOffsetType v;
+	v.set(data, 1, basis);
+
+	CHECK(data.empty());
+	CHECK(v.size() == 5);
+	CHECK(v.sector(0) == 1);
+	CHECK(v.qn(0) == basis.pseudoQn(1));
+	CHECK(v.offset() == 2);
+
+	VectorType extracted;
+	v.extract(extracted);
+	CHECK(extracted == VectorType({ 1.0, 2.0, 3.0 }));
+
+	VectorType replacement({ 4.0, 5.0, 6.0 });
+	v.setDataInSector(replacement, 0);
+	v.extract(extracted, 0);
+	CHECK(extracted == replacement);
+
+	std::vector<double> sparse;
+	v.toSparse(sparse);
+	CHECK(sparse == std::vector<double>({ 0.0, 0.0, 4.0, 5.0, 6.0 }));
+
+	v.clear();
+	CHECK(v.size() == 0);
+	CHECK(v.sectors() == 0);
+	CHECK(v.effectiveSize() == 0);
+	CHECK(v.offset() == 0);
+}
+
+TEST_CASE("VectorWithOffset converts from a full vector", "[VectorWithOffset]")
+{
+	const FakeBasis      basis;
+	VectorWithOffsetType v;
+	v.fromFull(VectorType({ 0.0, 0.0, 7.0, 8.0, 9.0 }), basis);
+
+	CHECK(v.size() == 5);
+	CHECK(v.sector(0) == 1);
+	CHECK(v.qn(0) == basis.pseudoQn(1));
+	CHECK(v.offset() == 2);
+	CHECK(v.effectiveSize() == 3);
+	CHECK(v.fastAccess(0, 0) == 7.0);
+	CHECK(v.slowAccess(4) == 9.0);
+	CHECK(v.index2Sector(1) == -1);
+	CHECK(v.index2Sector(2) == 0);
+	CHECK(v.index2Sector(4) == 0);
+	CHECK(v.index2Sector(5) == -1);
+}
+
+TEST_CASE("VectorWithOffset public arithmetic", "[VectorWithOffset]")
+{
+	const FakeBasis      basis;
+	VectorType           first({ 3.0, 4.0, 0.0 });
+	VectorWithOffsetType v;
+	v.set(first, 1, basis);
+
+	CHECK(norm(v) == Catch::Approx(5.0));
+	normalize(v);
+	CHECK(v.fastAccess(0, 0) == Catch::Approx(0.6));
+	CHECK(v.fastAccess(0, 1) == Catch::Approx(0.8));
+
+	v.fastAccess(0, 2) = 1.0;
+	v.slowAccess(2)    = 1.0;
+	v *= 2.0;
+	CHECK(v.fastAccess(0, 0) == Catch::Approx(2.0));
+
+	VectorWithOffsetType scaled = 0.5 * v;
+	CHECK(scaled.fastAccess(0, 0) == Catch::Approx(1.0));
+	CHECK(scaled * scaled == Catch::Approx(2.64));
+
+	VectorWithOffsetType sum;
+	sum += scaled;
+	sum += scaled;
+	CHECK(sum.fastAccess(0, 0) == Catch::Approx(2.0));
+	CHECK(sum.fastAccess(0, 1) == Catch::Approx(1.6));
+	CHECK(sum.fastAccess(0, 2) == Catch::Approx(2.0));
+
+	VectorWithOffsetType otherSector(2, 0, basis);
+	CHECK(scaled * otherSector == 0.0);
+	CHECK_THROWS_AS(sum += otherSector, PsimagLite::RuntimeError);
+}
+
+TEST_CASE("VectorWithOffset populates matching quantum-number sector", "[VectorWithOffset]")
+{
+	const FakeBasis      basis;
+	VectorType           data({ 1.0, 2.0, 3.0 });
+	VectorWithOffsetType source;
+	source.set(data, 1, basis);
+
+	VectorWithOffsetType destination;
+	destination.populateFromQns(source, basis);
+	CHECK(destination.size() == 5);
+	CHECK(destination.sector(0) == 1);
+	CHECK(destination.qn(0) == basis.pseudoQn(1));
+	CHECK(destination.offset() == 2);
+	CHECK(destination.effectiveSize() == 3);
+	CHECK(destination.fastAccess(0, 0) == 0.0);
+
+	destination.collapseSectors();
+	CHECK(destination.sectors() == 1);
+	CHECK_THROWS_AS(destination.populateSectors(basis), PsimagLite::RuntimeError);
+}
+
+TEST_CASE("VectorWithOffset writes and reads its public representation", "[VectorWithOffset]")
+{
+	const FakeBasis      basis;
+	VectorType           data({ 2.0, 4.0, 6.0 });
+	VectorWithOffsetType original;
+	original.set(data, 1, basis);
+
+	FakeIo io;
+	original.write(io, "vector");
+	CHECK(io.group() == "vector");
+
+	VectorWithOffsetType restored;
+	restored.read(io, "vector");
+	CHECK(restored.size() == original.size());
+	CHECK(restored.offset() == original.offset());
+	CHECK(restored.sector(0) == original.sector(0));
+	CHECK(restored.qn(0) == original.qn(0));
+	CHECK(restored * original == Catch::Approx(56.0));
+
+	VectorWithOffsetType loaded;
+	loaded.loadOneSector(io, "vector", 7);
+	CHECK(loaded * original == Catch::Approx(56.0));
+}

--- a/dmrg/Engine/tests/testVectorWithOffsets.cpp
+++ b/dmrg/Engine/tests/testVectorWithOffsets.cpp
@@ -1,0 +1,193 @@
+#include "Qn.h"
+#include "VectorWithOffsets.h"
+#include <PsimagLite/Vector.h>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+using VectorType            = PsimagLite::Vector<double>::Type;
+using VectorSizeType        = PsimagLite::Vector<SizeType>::Type;
+using VectorWithOffsetsType = Dmrg::VectorWithOffsets<double, Dmrg::Qn>;
+
+Dmrg::Qn makeQn(bool odd)
+{
+	return Dmrg::Qn(odd, VectorSizeType(), Dmrg::Qn::PairSizeType(0, 0), 0);
+}
+
+class FakeBasis {
+
+public:
+
+	FakeBasis()
+	    : partitions_({ 0, 2, 5, 6 })
+	    , qns_({ makeQn(false), makeQn(true), makeQn(false) })
+	{ }
+
+	SizeType        size() const { return partitions_.back(); }
+	SizeType        partition() const { return partitions_.size(); }
+	SizeType        partition(SizeType sector) const { return partitions_[sector]; }
+	const Dmrg::Qn& pseudoQn(SizeType sector) const { return qns_[sector]; }
+	const Dmrg::Qn& qnEx(SizeType sector) const { return qns_[sector]; }
+
+private:
+
+	VectorSizeType         partitions_;
+	Dmrg::Qn::VectorQnType qns_;
+};
+
+} // namespace
+
+TEST_CASE("VectorWithOffsets default state and identity", "[VectorWithOffsets]")
+{
+	VectorWithOffsetsType v;
+	CHECK(v.size() == 0);
+	CHECK(v.sectors() == 0);
+	CHECK(VectorWithOffsetsType::name() == "vectorwithoffsets");
+	CHECK(norm(v) == 0.0);
+}
+
+TEST_CASE("VectorWithOffsets constructs populated sectors", "[VectorWithOffsets]")
+{
+	const FakeBasis basis;
+
+	SECTION("weights for all basis sectors")
+	{
+		VectorSizeType        weights({ 2, 0, 1 });
+		VectorWithOffsetsType v(weights, basis);
+
+		CHECK(v.size() == 6);
+		CHECK(v.sectors() == 2);
+		CHECK(v.sector(0) == 0);
+		CHECK(v.sector(1) == 2);
+		CHECK(v.qn(0) == basis.pseudoQn(0));
+		CHECK(v.qn(1) == basis.pseudoQn(2));
+		CHECK(v.offset(0) == 0);
+		CHECK(v.offset(1) == 2);
+		CHECK(v.offset(2) == 5);
+		CHECK(v.offset(3) == 6);
+		CHECK(v.effectiveSize(0) == 2);
+		CHECK(v.effectiveSize(1) == 0);
+		CHECK(v.effectiveSize(2) == 1);
+		CHECK(v.index2Sector(0) == 0);
+		CHECK(v.index2Sector(2) == -1);
+		CHECK(v.index2Sector(5) == 2);
+	}
+
+	SECTION("compacted weights and explicit sectors")
+	{
+		VectorSizeType        weights({ 3, 1 });
+		VectorSizeType        sectors({ 1, 2 });
+		VectorWithOffsetsType v(weights, sectors, basis);
+		CHECK(v.sectors() == 2);
+		CHECK(v.sector(0) == 1);
+		CHECK(v.sector(1) == 2);
+		CHECK(v.effectiveSize(0) == 0);
+		CHECK(v.effectiveSize(1) == 3);
+		CHECK(v.effectiveSize(2) == 1);
+	}
+}
+
+TEST_CASE("VectorWithOffsets sets, extracts, and sparsifies data", "[VectorWithOffsets]")
+{
+	const FakeBasis       basis;
+	VectorType            data({ 3.0, 4.0, 5.0 });
+	VectorWithOffsetsType v;
+	v.set(data, 1, basis);
+
+	CHECK(data.empty());
+	CHECK(v.size() == 6);
+	CHECK(v.sectors() == 1);
+	CHECK(v.sector(0) == 1);
+	CHECK(v.qn(0) == basis.pseudoQn(1));
+	CHECK(v.index2Sector(1) == -1);
+	CHECK(v.index2Sector(2) == 1);
+
+	VectorType extracted;
+	v.extract(extracted, 1);
+	CHECK(extracted == VectorType({ 3.0, 4.0, 5.0 }));
+
+	VectorType replacement({ 6.0, 7.0, 8.0 });
+	v.setDataInSector(replacement, 1);
+	CHECK(v.fastAccess(1, 0) == 6.0);
+	v.fastAccess(1, 1) = 9.0;
+	CHECK(v.slowAccess(3) == 9.0);
+	v.slowAccess(4) = 10.0;
+
+	const VectorWithOffsetsType& constV = v;
+	CHECK(constV.slowAccess(0) == 0.0);
+	CHECK(constV.slowAccess(4) == 10.0);
+
+	std::vector<double> sparse;
+	v.toSparse(sparse);
+	CHECK(sparse == std::vector<double>({ 0.0, 0.0, 6.0, 9.0, 10.0, 0.0 }));
+
+	v.clear();
+	CHECK(v.size() == 0);
+	CHECK(v.sectors() == 0);
+}
+
+TEST_CASE("VectorWithOffsets converts a full vector", "[VectorWithOffsets]")
+{
+	const FakeBasis       basis;
+	VectorWithOffsetsType v;
+	v.fromFull(VectorType({ 1.0, 2.0, 0.0, 0.0, 0.0, 3.0 }), basis);
+
+	CHECK(v.size() == 6);
+	CHECK(v.sectors() == 2);
+	CHECK(v.sector(0) == 0);
+	CHECK(v.sector(1) == 2);
+	CHECK(v.fastAccess(0, 0) == 1.0);
+	CHECK(v.fastAccess(0, 1) == 2.0);
+	CHECK(v.fastAccess(2, 0) == 3.0);
+	CHECK(v.index2Sector(3) == -1);
+}
+
+TEST_CASE("VectorWithOffsets populates and collapses sectors", "[VectorWithOffsets]")
+{
+	const FakeBasis       basis;
+	VectorWithOffsetsType v;
+	v.populateSectors(basis);
+	CHECK(v.sectors() == 3);
+	CHECK(v.effectiveSize(0) == 2);
+	CHECK(v.effectiveSize(1) == 3);
+	CHECK(v.effectiveSize(2) == 1);
+
+	v.fastAccess(1, 1) = 2.0;
+	v.collapseSectors();
+	CHECK(v.sectors() == 1);
+	CHECK(v.sector(0) == 1);
+	CHECK(v.index2Sector(0) == -1);
+	CHECK(v.index2Sector(2) == 1);
+
+	VectorWithOffsetsType copy;
+	copy.populateFromQns(v, basis);
+	CHECK(copy.sectors() == 1);
+	CHECK(copy.sector(0) == 1);
+	CHECK(copy.effectiveSize(1) == 3);
+	CHECK(copy.fastAccess(1, 0) == 0.0);
+}
+
+TEST_CASE("VectorWithOffsets public arithmetic", "[VectorWithOffsets]")
+{
+	const FakeBasis       basis;
+	VectorType            data({ 3.0, 4.0, 0.0 });
+	VectorWithOffsetsType v;
+	v.set(data, 1, basis);
+
+	CHECK(norm(v) == Catch::Approx(5.0));
+	normalize(v);
+	CHECK(norm(v) == Catch::Approx(1.0));
+
+	v *= 2.0;
+	CHECK(v.fastAccess(1, 0) == Catch::Approx(1.2));
+	VectorWithOffsetsType scaled = 0.5 * v;
+	CHECK(scaled.fastAccess(1, 1) == Catch::Approx(0.8));
+	CHECK(scaled * scaled == Catch::Approx(1.0));
+
+	VectorWithOffsetsType sum;
+	sum += scaled;
+	sum += scaled;
+	CHECK(sum.fastAccess(1, 0) == Catch::Approx(1.2));
+	CHECK(sum.fastAccess(1, 1) == Catch::Approx(1.6));
+}

--- a/dmrg/Engine/tests/testVectorWithOffsets.cpp
+++ b/dmrg/Engine/tests/testVectorWithOffsets.cpp
@@ -2,13 +2,19 @@
 #include "VectorWithOffsets.h"
 #include <PsimagLite/Vector.h>
 #include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <complex>
 
 namespace {
 
-using VectorType            = PsimagLite::Vector<double>::Type;
-using VectorSizeType        = PsimagLite::Vector<SizeType>::Type;
-using VectorWithOffsetsType = Dmrg::VectorWithOffsets<double, Dmrg::Qn>;
+using VectorSizeType = PsimagLite::Vector<SizeType>::Type;
+
+template <typename T> void checkValue(const T& actual, double real, double imag = 0.0)
+{
+	CHECK(std::real(actual) == Catch::Approx(real));
+	CHECK(std::imag(actual) == Catch::Approx(imag));
+}
 
 Dmrg::Qn makeQn(bool odd)
 {
@@ -38,8 +44,12 @@ private:
 
 } // namespace
 
-TEST_CASE("VectorWithOffsets default state and identity", "[VectorWithOffsets]")
+TEMPLATE_TEST_CASE("VectorWithOffsets default state and identity",
+                   "[VectorWithOffsets]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	VectorWithOffsetsType v;
 	CHECK(v.size() == 0);
 	CHECK(v.sectors() == 0);
@@ -47,8 +57,12 @@ TEST_CASE("VectorWithOffsets default state and identity", "[VectorWithOffsets]")
 	CHECK(norm(v) == 0.0);
 }
 
-TEST_CASE("VectorWithOffsets constructs populated sectors", "[VectorWithOffsets]")
+TEMPLATE_TEST_CASE("VectorWithOffsets constructs populated sectors",
+                   "[VectorWithOffsets]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis basis;
 
 	SECTION("weights for all basis sectors")
@@ -88,8 +102,13 @@ TEST_CASE("VectorWithOffsets constructs populated sectors", "[VectorWithOffsets]
 	}
 }
 
-TEST_CASE("VectorWithOffsets sets, extracts, and sparsifies data", "[VectorWithOffsets]")
+TEMPLATE_TEST_CASE("VectorWithOffsets sets, extracts, and sparsifies data",
+                   "[VectorWithOffsets]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType            = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorType            data({ 3.0, 4.0, 5.0 });
 	VectorWithOffsetsType v;
@@ -109,26 +128,31 @@ TEST_CASE("VectorWithOffsets sets, extracts, and sparsifies data", "[VectorWithO
 
 	VectorType replacement({ 6.0, 7.0, 8.0 });
 	v.setDataInSector(replacement, 1);
-	CHECK(v.fastAccess(1, 0) == 6.0);
+	checkValue(v.fastAccess(1, 0), 6.0);
 	v.fastAccess(1, 1) = 9.0;
-	CHECK(v.slowAccess(3) == 9.0);
+	checkValue(v.slowAccess(3), 9.0);
 	v.slowAccess(4) = 10.0;
 
 	const VectorWithOffsetsType& constV = v;
-	CHECK(constV.slowAccess(0) == 0.0);
-	CHECK(constV.slowAccess(4) == 10.0);
+	checkValue(constV.slowAccess(0), 0.0);
+	checkValue(constV.slowAccess(4), 10.0);
 
-	std::vector<double> sparse;
+	std::vector<TestType> sparse;
 	v.toSparse(sparse);
-	CHECK(sparse == std::vector<double>({ 0.0, 0.0, 6.0, 9.0, 10.0, 0.0 }));
+	CHECK(sparse == std::vector<TestType>({ 0.0, 0.0, 6.0, 9.0, 10.0, 0.0 }));
 
 	v.clear();
 	CHECK(v.size() == 0);
 	CHECK(v.sectors() == 0);
 }
 
-TEST_CASE("VectorWithOffsets converts a full vector", "[VectorWithOffsets]")
+TEMPLATE_TEST_CASE("VectorWithOffsets converts a full vector",
+                   "[VectorWithOffsets]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType            = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorWithOffsetsType v;
 	v.fromFull(VectorType({ 1.0, 2.0, 0.0, 0.0, 0.0, 3.0 }), basis);
@@ -143,8 +167,12 @@ TEST_CASE("VectorWithOffsets converts a full vector", "[VectorWithOffsets]")
 	CHECK(v.index2Sector(3) == -1);
 }
 
-TEST_CASE("VectorWithOffsets populates and collapses sectors", "[VectorWithOffsets]")
+TEMPLATE_TEST_CASE("VectorWithOffsets populates and collapses sectors",
+                   "[VectorWithOffsets]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorWithOffsetsType v;
 	v.populateSectors(basis);
@@ -168,8 +196,13 @@ TEST_CASE("VectorWithOffsets populates and collapses sectors", "[VectorWithOffse
 	CHECK(copy.fastAccess(1, 0) == 0.0);
 }
 
-TEST_CASE("VectorWithOffsets public arithmetic", "[VectorWithOffsets]")
+TEMPLATE_TEST_CASE("VectorWithOffsets public arithmetic",
+                   "[VectorWithOffsets]",
+                   double,
+                   std::complex<double>)
 {
+	using VectorType            = typename PsimagLite::Vector<TestType>::Type;
+	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorType            data({ 3.0, 4.0, 0.0 });
 	VectorWithOffsetsType v;
@@ -180,14 +213,14 @@ TEST_CASE("VectorWithOffsets public arithmetic", "[VectorWithOffsets]")
 	CHECK(norm(v) == Catch::Approx(1.0));
 
 	v *= 2.0;
-	CHECK(v.fastAccess(1, 0) == Catch::Approx(1.2));
+	checkValue(v.fastAccess(1, 0), 1.2);
 	VectorWithOffsetsType scaled = 0.5 * v;
-	CHECK(scaled.fastAccess(1, 1) == Catch::Approx(0.8));
-	CHECK(scaled * scaled == Catch::Approx(1.0));
+	checkValue(scaled.fastAccess(1, 1), 0.8);
+	checkValue(scaled * scaled, 1.0);
 
 	VectorWithOffsetsType sum;
 	sum += scaled;
 	sum += scaled;
-	CHECK(sum.fastAccess(1, 0) == Catch::Approx(1.2));
-	CHECK(sum.fastAccess(1, 1) == Catch::Approx(1.6));
+	checkValue(sum.fastAccess(1, 0), 1.2);
+	checkValue(sum.fastAccess(1, 1), 1.6);
 }

--- a/dmrg/Engine/tests/testVectorWithOffsets.cpp
+++ b/dmrg/Engine/tests/testVectorWithOffsets.cpp
@@ -1,14 +1,14 @@
 #include "Qn.h"
 #include "VectorWithOffsets.h"
-#include <PsimagLite/Vector.h>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <complex>
+#include <vector>
 
 namespace {
 
-using VectorSizeType = PsimagLite::Vector<SizeType>::Type;
+using VectorSizeType = std::vector<SizeType>;
 
 template <typename T> void checkValue(const T& actual, double real, double imag = 0.0)
 {
@@ -38,8 +38,8 @@ public:
 
 private:
 
-	VectorSizeType         partitions_;
-	Dmrg::Qn::VectorQnType qns_;
+	VectorSizeType        partitions_;
+	std::vector<Dmrg::Qn> qns_;
 };
 
 } // namespace
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("VectorWithOffsets sets, extracts, and sparsifies data",
                    double,
                    std::complex<double>)
 {
-	using VectorType            = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType            = std::vector<TestType>;
 	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorType            data({ 3.0, 4.0, 5.0 });
@@ -151,7 +151,7 @@ TEMPLATE_TEST_CASE("VectorWithOffsets converts a full vector",
                    double,
                    std::complex<double>)
 {
-	using VectorType            = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType            = std::vector<TestType>;
 	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorWithOffsetsType v;
@@ -201,7 +201,7 @@ TEMPLATE_TEST_CASE("VectorWithOffsets public arithmetic",
                    double,
                    std::complex<double>)
 {
-	using VectorType            = typename PsimagLite::Vector<TestType>::Type;
+	using VectorType            = std::vector<TestType>;
 	using VectorWithOffsetsType = Dmrg::VectorWithOffsets<TestType, Dmrg::Qn>;
 	const FakeBasis       basis;
 	VectorType            data({ 3.0, 4.0, 0.0 });


### PR DESCRIPTION
This PR is part of a series to reduce compilation time by merging VectorWithOffset into VectorWithOffsets. This PR adds unit tests to VWO and VWOs and documents only the latter given that the former will be deleted in an upcoming PR. See https://github.com/dmrgpp-project/dmrgpp/pull/250 for how the finished series will look like.