### PR TITLE
fixes `@auto` for all odd site lattices

### DIFF
--- a/TestSuite/inputs/descriptions.txt
+++ b/TestSuite/inputs/descriptions.txt
@@ -126,6 +126,10 @@ Page* where more or less this feature is used: 2230
 72) @auto for 4 sites
 73) @auto restart from 72
 74) @auto for a lattice with 3 sites
+75) @auto for 5 sites; odd sweeps
+76) @auto restart from 75
+77) @auto for 5 sites; even sweeps
+78) @auto restart from 77
 80) Heisenberg spin 1 with 6 sites
 82) Heisenberg spin 1 with 6 sites AnistropyD=4
 84) Heisenberg spin 1 with 6 sites J = 0 AnistropyE=4

--- a/TestSuite/inputs/input75.ain
+++ b/TestSuite/inputs/input75.ain
@@ -7,7 +7,7 @@ DegreesOfFreedom   = 1;
 GeometryKind       = "chain";
 GeometryOptions    = "ConstantValues";
 dir0:Connectors    = [-1];
-hubbardU           = [8.0, ...];
+hubbardU           = [7.3, ...];
 potentialV         = [0.0, ...];
 Model              = "HubbardOneBand";
 

--- a/TestSuite/inputs/input75.ain
+++ b/TestSuite/inputs/input75.ain
@@ -1,0 +1,32 @@
+##Ainur1.0
+
+# --- Model parameters ---
+TotalNumberOfSites = 5;
+NumberOfTerms      = 1;
+DegreesOfFreedom   = 1;
+GeometryKind       = "chain";
+GeometryOptions    = "ConstantValues";
+dir0:Connectors    = [-1];
+hubbardU           = [8.0, ...];
+potentialV         = [0.0, ...];
+Model              = "HubbardOneBand";
+
+# --- Fock Space parameters --- #
+TargetElectronsUp   = 2;
+TargetElectronsDown = 2;
+
+# --- DMRG++ control parameters --- #
+InfiniteLoopKeptStates = 128;
+TruncationTolerance = 1e-09;
+FiniteLoops = [
+    [@auto, 1000, 0],
+    [@auto, 1000, 0],
+    [@auto, 1000, 0],
+    [@auto, 1000, 0],
+    [@auto, 1000, 0]
+];
+
+# --- Solver / run control -- #
+SolverOptions   = "twositedmrg,usecomplex,geometryallinsystem";
+Version         = "Pierls";
+OutputFile      = "data75";

--- a/TestSuite/inputs/input76.ain
+++ b/TestSuite/inputs/input76.ain
@@ -1,0 +1,35 @@
+##Ainur1.0
+
+# --- Model parameters ---
+TotalNumberOfSites = 5;
+NumberOfTerms      = 1;
+DegreesOfFreedom   = 1;
+GeometryKind       = "chain";
+GeometryOptions    = "ConstantValues";
+dir0:Connectors    = [-1];
+hubbardU           = [7.3, ...];
+potentialV         = [0.0, ...];
+Model              = "HubbardOneBand";
+
+# --- Fock Space parameters --- #
+TargetElectronsUp   = 2;
+TargetElectronsDown = 2;
+
+# --- DMRG++ control parameters --- #
+TruncationTolerance = 1e-09;
+FiniteLoops = [
+    [@auto, 1000, 2],
+    [@auto, 1000, 2]
+];
+RepeatFiniteLoopsTimes = 1;
+TSPTau = 0.1;
+TSPTimeSteps = 5;
+TSPAdvanceEach = 4;
+TSPAlgorithm = Krylov;
+
+# --- Solver / run control -- #
+SolverOptions   = "twositedmrg,TimeStepTargeting,restart,usecomplex,geometryallinsystem";
+Version         = "Pierls";
+OutputFile      = "data76";
+RestartFilename = "data75";
+GsWeight        = 0.2;

--- a/TestSuite/inputs/input77.ain
+++ b/TestSuite/inputs/input77.ain
@@ -7,7 +7,7 @@ DegreesOfFreedom   = 1;
 GeometryKind       = "chain";
 GeometryOptions    = "ConstantValues";
 dir0:Connectors    = [-1];
-hubbardU           = [8.0, ...];
+hubbardU           = [7.3, ...];
 potentialV         = [0.0, ...];
 Model              = "HubbardOneBand";
 

--- a/TestSuite/inputs/input77.ain
+++ b/TestSuite/inputs/input77.ain
@@ -1,0 +1,31 @@
+##Ainur1.0
+
+# --- Model parameters ---
+TotalNumberOfSites = 5;
+NumberOfTerms      = 1;
+DegreesOfFreedom   = 1;
+GeometryKind       = "chain";
+GeometryOptions    = "ConstantValues";
+dir0:Connectors    = [-1];
+hubbardU           = [8.0, ...];
+potentialV         = [0.0, ...];
+Model              = "HubbardOneBand";
+
+# --- Fock Space parameters --- #
+TargetElectronsUp   = 2;
+TargetElectronsDown = 2;
+
+# --- DMRG++ control parameters --- #
+InfiniteLoopKeptStates = 128;
+TruncationTolerance = 1e-09;
+FiniteLoops = [
+    [@auto, 1000, 0],
+    [@auto, 1000, 0],
+    [@auto, 1000, 0],
+    [@auto, 1000, 0]
+];
+
+# --- Solver / run control -- #
+SolverOptions   = "twositedmrg,usecomplex,geometryallinsystem";
+Version         = "Pierls";
+OutputFile      = "data77";

--- a/TestSuite/inputs/input78.ain
+++ b/TestSuite/inputs/input78.ain
@@ -1,0 +1,35 @@
+##Ainur1.0
+
+# --- Model parameters ---
+TotalNumberOfSites = 5;
+NumberOfTerms      = 1;
+DegreesOfFreedom   = 1;
+GeometryKind       = "chain";
+GeometryOptions    = "ConstantValues";
+dir0:Connectors    = [-1];
+hubbardU           = [7.3, ...];
+potentialV         = [0.0, ...];
+Model              = "HubbardOneBand";
+
+# --- Fock Space parameters --- #
+TargetElectronsUp   = 2;
+TargetElectronsDown = 2;
+
+# --- DMRG++ control parameters --- #
+TruncationTolerance = 1e-09;
+FiniteLoops = [
+    [@auto, 1000, 2],
+    [@auto, 1000, 2]
+];
+RepeatFiniteLoopsTimes = 1;
+TSPTau = 0.1;
+TSPTimeSteps = 5;
+TSPAdvanceEach = 4;
+TSPAlgorithm = Krylov;
+
+# --- Solver / run control -- #
+SolverOptions   = "twositedmrg,TimeStepTargeting,restart,usecomplex,geometryallinsystem";
+Version         = "Pierls";
+OutputFile      = "data78";
+RestartFilename = "data77";
+GsWeight        = 0.2;

--- a/dmrg/CMakeLists.txt
+++ b/dmrg/CMakeLists.txt
@@ -201,14 +201,14 @@ add_test(NAME input73 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input73.ain) # energy 
 add_lowest_eigenvalue_check_test(output73 input73 -4.47214 runForinput73.cout)
 add_test(NAME input74 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input74.ain) # energy -0.707712
 add_lowest_eigenvalue_check_test(output74 input74 -0.707712 runForinput74.cout)
-add_test(NAME input75 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input75.ain) # energy -0.707712
-add_lowest_eigenvalue_check_test(output75 input75 -0.707712 runForinput75.cout)
+add_test(NAME input75 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input75.ain) # energy -2.80627
+add_lowest_eigenvalue_check_test(output75 input75 -2.80627 runForinput75.cout)
 add_test(NAME input76 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input76.ain) # energy -0.707712
-#add_lowest_eigenvalue_check_test(output76 input76 -0.707712 runForinput76.cout)
-add_test(NAME input77 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input77.ain) # energy -0.707712
-#add_lowest_eigenvalue_check_test(output77 input77 -0.707712 runForinput77.cout)
+# input76 is a restart check only; no g.s. computation
+add_test(NAME input77 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input77.ain) # energy -2.80627
+add_lowest_eigenvalue_check_test(output77 input77 -2.80627 runForinput77.cout)
 add_test(NAME input78 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input78.ain) # energy -0.707712
-#add_lowest_eigenvalue_check_test(output78 input78 -0.707712 runForinput78.cout)
+# input78 is a restart check only; no g.s. computation
 add_test(NAME input80 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input80.ain) # energy -7.37027
 add_lowest_eigenvalue_check_test(output80 input80 -7.37027 runForinput80.cout)
 add_test(NAME input120 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input120.ain) # energy -9.51754

--- a/dmrg/CMakeLists.txt
+++ b/dmrg/CMakeLists.txt
@@ -201,6 +201,14 @@ add_test(NAME input73 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input73.ain) # energy 
 add_lowest_eigenvalue_check_test(output73 input73 -4.47214 runForinput73.cout)
 add_test(NAME input74 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input74.ain) # energy -0.707712
 add_lowest_eigenvalue_check_test(output74 input74 -0.707712 runForinput74.cout)
+add_test(NAME input75 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input75.ain) # energy -0.707712
+add_lowest_eigenvalue_check_test(output75 input75 -0.707712 runForinput75.cout)
+add_test(NAME input76 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input76.ain) # energy -0.707712
+#add_lowest_eigenvalue_check_test(output76 input76 -0.707712 runForinput76.cout)
+add_test(NAME input77 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input77.ain) # energy -0.707712
+#add_lowest_eigenvalue_check_test(output77 input77 -0.707712 runForinput77.cout)
+add_test(NAME input78 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input78.ain) # energy -0.707712
+#add_lowest_eigenvalue_check_test(output78 input78 -0.707712 runForinput78.cout)
 add_test(NAME input80 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input80.ain) # energy -7.37027
 add_lowest_eigenvalue_check_test(output80 input80 -7.37027 runForinput80.cout)
 add_test(NAME input120 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input120.ain) # energy -9.51754

--- a/dmrg/Engine/ParametersDmrgSolver.h
+++ b/dmrg/Engine/ParametersDmrgSolver.h
@@ -568,16 +568,17 @@ struct ParametersDmrgSolver {
 	{
 		SizeType numberOfSites = 0;
 		io.readline(numberOfSites, "TotalNumberOfSites=");
-		bool latticeIsOdd = (numberOfSites & 1);
 
 		using AlgebraicStringToNumberType = AlgebraicStringToNumber<FieldType>;
 		AlgebraicStringToNumberType algebraicStringToNumber("FiniteLoops", numberOfSites);
 
 		std::cout << "FiniteLoopLengths=[";
 
-		// For restarts and even (regular lattices), lastSite == 1 indicated
-		// by the previous run is really the leftmost border 0
-		if (lastSite == 1 && isRestart && !latticeIsOdd) {
+		// For restarts and even (regular) lattices, lastSite == 1 indicated
+		// by the previous run is really the leftmost border 0.
+		// The algorithm for numberOfSites == 3 is different and special.
+		// DMRG++ currently doesn't support numberOfSites < 3.
+		if (lastSite == 1 && isRestart && numberOfSites > 3) {
 			lastSite = 0;
 		}
 

--- a/dmrg/Engine/ParametersDmrgSolver.h
+++ b/dmrg/Engine/ParametersDmrgSolver.h
@@ -574,8 +574,8 @@ struct ParametersDmrgSolver {
 
 		std::cout << "FiniteLoopLengths=[";
 
-		// For restarts and even (regular) lattices, lastSite == 1 indicated
-		// by the previous run is really the leftmost border 0.
+		// For restarts, lastSite == 1 indicated by the previous run is really the
+		// leftmost border site 0.
 		// The algorithm for numberOfSites == 3 is different and special.
 		// DMRG++ currently doesn't support numberOfSites < 3.
 		if (lastSite == 1 && isRestart && numberOfSites > 3) {


### PR DESCRIPTION
The case of lattice sites equals three was special; this PR leaves that case alone and fixes all other odd lattices.