### PR TITLE
GPUPlugin: Remove unused macros and functions

### DIFF
--- a/dmrg/GPUPlugin/dmrg_vbatch.cpp
+++ b/dmrg/GPUPlugin/dmrg_vbatch.cpp
@@ -64,21 +64,21 @@ void dmrg_finalize()
 	for (idev = 0; idev < MAXGPUS; idev++) {
 		if (queue_array[idev] != 0) {
 			magma_queue_destroy(queue_array[idev]);
-		};
-	};
+		}
+	}
 	magma_finalize();
 #endif
 }
 
 #ifdef USE_MAGMA
-IntegerType dmrg_get_ngpu() { return ngpu; };
+IntegerType dmrg_get_ngpu() { return ngpu; }
 
 IntegerType dmrg_set_max_gpus(const IntegerType max_gpus_in)
 {
 	const IntegerType prev_max_gpus = max_gpus;
 	if (max_gpus > max_gpus_in) {
 		max_gpus = max_gpus_in;
-	};
+	}
 	return (prev_max_gpus);
 }
 #endif
@@ -99,13 +99,13 @@ void dmrg_init()
 
 		if (idebug >= 1) {
 			printf("dmrg_init: ngpu = %d detected \n", ngpu);
-		};
+		}
 
 		max_gpus = (max_gpus >= MAXGPUS) ? MAXGPUS : max_gpus;
 		ngpu     = (ngpu >= max_gpus) ? max_gpus : ngpu;
 		if (idebug >= 1) {
 			printf("dmrg_init: ngpu = %d used \n", ngpu);
-		};
+		}
 
 		IntegerType idev = 0;
 		for (idev = 0; idev < ngpu; idev++) {
@@ -115,74 +115,14 @@ void dmrg_init()
 			magma_queue_create(device, &queue);
 			assert(queue != 0);
 			queue_array[idev] = queue;
-		};
+		}
 
 		idev   = 0;
 		queue  = queue_array[idev];
 		device = device_array[idev];
 
 #endif
-	};
-}
-
-template <typename T>
-void dmrg_Xgetvector(const IntegerType n,
-                     T*                dx_src,
-                     const IntegerType incx,
-                     T*                hy_dst,
-                     const IntegerType incy)
-{
-#ifdef USE_MAGMA
-	magma_Xgetvector(n, dx_src, incx, hy_dst, incy, queue);
-#else
-	Xcopy_(&n, dx_src, &incx, hy_dst, &incy);
-#endif
-}
-
-template <typename T>
-void dmrg_Xsetvector(const IntegerType n,
-                     const T*          hx_src,
-                     const IntegerType incx,
-                     T*                dy_dst,
-                     const IntegerType incy)
-{
-#ifdef USE_MAGMA
-	magma_Xsetvector(n, hx_src, incx, dy_dst, incy, queue);
-#else
-	Xcopy_(&n, hx_src, &incx, dy_dst, &incy);
-#endif
-}
-
-template <typename T>
-void dmrg_Xgetmatrix(const IntegerType m,
-                     const IntegerType n,
-                     T*                dA_src,
-                     const IntegerType ldda,
-                     T*                hB_dst,
-                     const IntegerType ldb)
-{
-#ifdef USE_MAGMA
-	magma_Xgetmatrix(m, n, dA_src, ldda, hB_dst, ldb, queue);
-#else
-	const char* uplo = "A";
-	Xlacpy_(uplo, &m, &n, dA_src, &ldda, hB_dst, &ldb);
-#endif
-}
-
-template <typename T>
-void dmrg_Xsetmatrix(const IntegerType m,
-                     const IntegerType n,
-                     const T*          hA_src,
-                     const IntegerType lda,
-                     T*                dB_dst,
-                     const IntegerType lddb)
-{
-#ifdef USE_MAGMA
-	magma_Xsetmatrix(m, n, hA_src, lda, dB_dst, lddb, queue);
-#else
-	const char* uplo = "A";
-	Xlacpy_(uplo, &m, &n, hA_src, &lda, dB_dst, &lddb);
-#endif
+	}
 }
 
 template <typename T>
@@ -220,9 +160,9 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 
 			gflops += ((double)m_array[igroup]) * ((double)n_array[igroup])
 			    * ((double)k_array[igroup]) * ((double)group_size[igroup]) * 2.0;
-		};
+		}
 		gflops = gflops / (giga);
-	};
+	}
 
 	/*
 	---------------------
@@ -232,7 +172,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 	IntegerType batch_size = 0;
 	for (SizeType igroup = 0; igroup < group_count; igroup++) {
 		batch_size += group_size[igroup];
-	};
+	}
 
 	/*
    ----------------------------------------------------------
@@ -298,8 +238,8 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 			c_vbatch[idx] = reinterpret_cast<KokkosScalar*>(c_array[idx]);
 
 			idx = idx + 1;
-		};
-	};
+		}
+	}
 
 #ifdef USE_MAGMA
 	/*
@@ -349,7 +289,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 					    nn,
 					    kk);
 					fflush(stderr);
-				};
+				}
 
 				IntegerType is_ok_lda = (lda >= 1);
 				IntegerType is_ok_ldb = (ldb >= 1);
@@ -367,7 +307,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 					    ldb,
 					    ldc);
 					fflush(stderr);
-				};
+				}
 
 				assert(mm >= 1);
 				assert(nn >= 1);
@@ -376,8 +316,8 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 				assert(lda >= 1);
 				assert(ldb >= 1);
 				assert(ldc >= 1);
-			};
-		};
+			}
+		}
 
 		if (ngpu == 1) {
 
@@ -394,11 +334,11 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 					max_m = std::max(m, max_m);
 					max_n = std::max(n, max_n);
 					max_k = std::max(k, max_k);
-				};
+				}
 				if (idebug >= 1) {
 					printf(
 					    "max_m=%d, max_n=%d, max_k=%d\n", max_m, max_n, max_k);
-				};
+				}
 
 				magmablas_Xgemm_vbatched_max_nocheck(transA,
 				                                     transB,
@@ -451,7 +391,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 				IntegerType iend   = istart + inc - 1;
 				if (iend >= (batch_size - 1)) {
 					iend = batch_size - 1;
-				};
+				}
 				IntegerType isize = (iend - istart + 1);
 				if (idebug >= 1) {
 					printf("idev=%d, istart=%d, iend=%d, isize=%d\n",
@@ -459,7 +399,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 					       istart,
 					       iend,
 					       isize);
-				};
+				}
 
 				device = device_array[idev];
 				queue  = queue_array[idev];
@@ -505,8 +445,8 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 						plda_vbatch[i] = lda_vbatch[istart + i];
 						pldb_vbatch[i] = ldb_vbatch[istart + i];
 						pldc_vbatch[i] = ldc_vbatch[istart + i];
-					};
-				};
+					}
+				}
 
 				double      gmem   = 0;
 				double      gflops = 0;
@@ -526,7 +466,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 
 						gmem += m * n + m * k + k * n;
 						gflops += 2.0 * m * n * k;
-					};
+					}
 
 					double gmem_in_bytes = gmem * sizeof(T);
 
@@ -535,7 +475,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 						       idev,
 						       gmem_in_bytes,
 						       gflops);
-					};
+					}
 				}
 
 				/*
@@ -561,7 +501,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 
 				gBatchCount[idev] = isize;
 
-			}; /* end for idev */
+			} /* end for idev */
 
 			/*
 			 * -------------------------
@@ -626,9 +566,9 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 					                                     max_n,
 					                                     max_k,
 					                                     queue);
-				};
+				}
 
-			}; /* end for idev */
+			} /* end for idev */
 
 			/*
 			 * -------------------------------
@@ -640,7 +580,7 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 				queue  = queue_array[idev];
 				magma_setdevice(device);
 				magma_queue_sync(queue);
-			};
+			}
 
 			for (idev = 0; idev < ngpu; idev++) {
 				KokkosScalar** pa_vbatch = gpa_vbatch[idev];
@@ -656,8 +596,8 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 			device = device_array[idev];
 			queue  = queue_array[idev];
 
-		}; /* end if (ngpu > 1) */
-	};
+		} /* end if (ngpu > 1) */
+	}
 #else
 	{
 		IntegerType i = 0;
@@ -686,8 +626,8 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 			       &beta,
 			       pc,
 			       &ldc);
-		};
-	};
+		}
+	}
 #endif
 
 	Kokkos::kokkos_free<Kokkos::SharedSpace>(a_vbatch);
@@ -699,14 +639,14 @@ void dmrg_Xgemm_vbatch(char         ctransa,
 		double gflops_per_sec = 0;
 		if (elapsed_time > 0) {
 			gflops_per_sec = gflops / elapsed_time;
-		};
+		}
 
 		printf("dmrg_vbatch: gflops=%lf, elapsed_time=%lf, gflops/sec=%lf\n",
 		       gflops,
 		       elapsed_time,
 		       gflops_per_sec);
 		printf("dmrg_vbatch need %lf GBytes\n", (double)nbytes_total / (giga));
-	};
+	}
 }
 
 template void dmrg_Xgemm_vbatch<double>(char,
@@ -740,52 +680,3 @@ template void dmrg_Xgemm_vbatch<std::complex<double>>(char                      
                                                       IntegerType*                 ldc_array,
                                                       SizeType                     group_count,
                                                       IntegerType*                 group_size);
-
-template void
-dmrg_Xgetvector<double>(const IntegerType, double*, const IntegerType, double*, const IntegerType);
-
-template void dmrg_Xgetvector<std::complex<double>>(const IntegerType,
-                                                    std::complex<double>*,
-                                                    const IntegerType,
-                                                    std::complex<double>*,
-                                                    const IntegerType);
-
-template void dmrg_Xsetvector<double>(const IntegerType,
-                                      const double*,
-                                      const IntegerType,
-                                      double*,
-                                      const IntegerType);
-
-template void dmrg_Xsetvector<std::complex<double>>(const IntegerType,
-                                                    const std::complex<double>*,
-                                                    const IntegerType,
-                                                    std::complex<double>*,
-                                                    const IntegerType);
-
-template void dmrg_Xgetmatrix<double>(const IntegerType,
-                                      const IntegerType,
-                                      double*,
-                                      const IntegerType,
-                                      double*,
-                                      const IntegerType);
-
-template void dmrg_Xgetmatrix<std::complex<double>>(const IntegerType,
-                                                    const IntegerType,
-                                                    std::complex<double>*,
-                                                    const IntegerType,
-                                                    std::complex<double>*,
-                                                    const IntegerType);
-
-template void dmrg_Xsetmatrix<double>(const IntegerType,
-                                      const IntegerType,
-                                      const double*,
-                                      const IntegerType,
-                                      double*,
-                                      const IntegerType);
-
-template void dmrg_Xsetmatrix<std::complex<double>>(const IntegerType,
-                                                    const IntegerType,
-                                                    const std::complex<double>*,
-                                                    const IntegerType,
-                                                    std::complex<double>*,
-                                                    const IntegerType);

--- a/dmrg/GPUPlugin/dmrg_vbatch.h
+++ b/dmrg/GPUPlugin/dmrg_vbatch.h
@@ -54,38 +54,6 @@ void dmrg_lacpy(const char*       uplo,
                 T*                dest,
                 const IntegerType ld_dest);
 
-template <typename T> void dmrg_free(T* a_ptr);
-
-template <typename T>
-void dmrg_Xgetvector(const IntegerType n,
-                     const T*          dx_src,
-                     const IntegerType incx,
-                     T*                hy_dst,
-                     const IntegerType incy);
-
-template <typename T>
-void dmrg_Xsetvector(const IntegerType n,
-                     const T*          hx_src,
-                     const IntegerType incx,
-                     T*                dy_dst,
-                     const IntegerType incy);
-
-template <typename T>
-void dmrg_Xgetmatrix(const IntegerType m,
-                     const IntegerType n,
-                     const T*          dA_src,
-                     const IntegerType ldda,
-                     T*                hB_dst,
-                     const IntegerType ldb);
-
-template <typename T>
-void dmrg_Xsetmatrix(const IntegerType m,
-                     const IntegerType n,
-                     const T*          hA_src,
-                     const IntegerType lda,
-                     T*                dB_dst,
-                     const IntegerType lddb);
-
 template <typename T>
 void apply_Htarget_vbatch(
     SizeType       noperator,

--- a/dmrg/GPUPlugin/setup_sparse_batch.cpp
+++ b/dmrg/GPUPlugin/setup_sparse_batch.cpp
@@ -43,12 +43,11 @@ void setup_sparse_batch(
  ---------------------------------------------------------
 */
 {
-	const IntegerType idebug     = 1;
-	const IntegerType ialign     = 32;
-	const IntegerType lfalse     = 0;
-	const IntegerType ltrue      = !lfalse;
-	const IntegerType use_Xlacpy = ltrue;
-	const double      giga       = 1000.0 * 1000.0 * 1000.0;
+	const IntegerType idebug = 1;
+	const IntegerType ialign = 32;
+	const IntegerType lfalse = 0;
+	const IntegerType ltrue  = !lfalse;
+	const double      giga   = 1000.0 * 1000.0 * 1000.0;
 
 	double total_time = -dmrg_get_wtime();
 
@@ -313,13 +312,7 @@ void setup_sparse_batch(
 						assert(isok);
 						(void)isok;
 
-						if (use_Xlacpy) {
-							Xlacpy_(
-							    uplo, &m, &n, Asrc, &ld1, Adest, &ld2);
-						} else {
-							dmrg_lacpy(
-							    uplo, m, n, Asrc, ld1, Adest, ld2);
-						};
+						dmrg_lacpy(uplo, m, n, Asrc, ld1, Adest, ld2);
 
 						Adest += (ld2 * n);
 					};
@@ -337,13 +330,7 @@ void setup_sparse_batch(
 						assert(isok);
 						(void)isok;
 
-						if (use_Xlacpy) {
-							Xlacpy_(
-							    uplo, &m, &n, Bsrc, &ld1, Bdest, &ld2);
-						} else {
-							dmrg_lacpy(
-							    uplo, m, n, Bsrc, ld1, Bdest, ld2);
-						}
+						dmrg_lacpy(uplo, m, n, Bsrc, ld1, Bdest, ld2);
 
 						Bdest += (ld2 * n);
 					}

--- a/dmrg/GPUPlugin/setup_vbatch.cpp
+++ b/dmrg/GPUPlugin/setup_vbatch.cpp
@@ -44,7 +44,7 @@ void     print_nnz(SizeType              noperator,
 		    fid_A, "left_patch_size(%lu) = %lu;\n", ipatch, left_patch_size_[(ipatch)-1]);
 		fprintf(
 		    fid_B, "right_patch_size(%lu) = %lu;\n", ipatch, right_patch_size_[(ipatch)-1]);
-	};
+	}
 
 	fprintf(fid_A, "gnnz_A = zeros([%lu,%lu,%lu]);\n", npatches, npatches, noperator);
 	fprintf(fid_B, "gnnz_B = zeros([%lu,%lu,%lu]);\n", npatches, npatches, noperator);
@@ -60,7 +60,7 @@ void     print_nnz(SizeType              noperator,
 					    jpatch,
 					    ioperator,
 					    gnnz_A_[index3(ipatch, jpatch, ioperator, npatches)]);
-				};
+				}
 
 				if (gnnz_B_[index3(ipatch, jpatch, ioperator, npatches)] > 0) {
 					fprintf(
@@ -70,10 +70,10 @@ void     print_nnz(SizeType              noperator,
 					    jpatch,
 					    ioperator,
 					    gnnz_B_[index3(ipatch, jpatch, ioperator, npatches)]);
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	SizeType istat_A = fclose(fid_A);
 	SizeType istat_B = fclose(fid_B);
@@ -128,8 +128,8 @@ void setup_vbatch(
 			nnz_B[i]     = 0;
 			nnz_Adiag[i] = 0;
 			nnz_Bdiag[i] = 0;
-		};
-	};
+		}
+	}
 
 	SizeType left_max_state  = 0;
 	SizeType right_max_state = 0;
@@ -141,7 +141,7 @@ void setup_vbatch(
 
 			assert(left_patch_size_[(ipatch)-1] >= 1);
 			assert(right_patch_size_[(ipatch)-1] >= 1);
-		};
+		}
 	}
 
 	SizeType nrow_Abatch = left_max_state;
@@ -175,20 +175,20 @@ void setup_vbatch(
 	for (ipatch = 1; ipatch <= npatches; ipatch++) {
 		left_patch_start_[ipatch]
 		    = left_patch_start_[(ipatch)-1] + left_patch_size_[(ipatch)-1];
-	};
+	}
 
 	right_patch_start_[0] = 1;
 	for (ipatch = 1; ipatch <= npatches; ipatch++) {
 		right_patch_start_[ipatch]
 		    = right_patch_start_[(ipatch)-1] + right_patch_size_[(ipatch)-1];
-	};
+	}
 
 	xy_patch_start_[0] = 1;
 	for (ipatch = 1; ipatch <= npatches; ipatch++) {
 		SizeType nrowX          = right_patch_size_[(ipatch)-1];
 		SizeType ncolX          = left_patch_size_[(ipatch)-1];
 		xy_patch_start_[ipatch] = xy_patch_start_[(ipatch)-1] + (nrowX * ncolX);
-	};
+	}
 
 	/*
 	 ---------------------------
@@ -213,14 +213,10 @@ void setup_vbatch(
 		assert(size_Bbatch >= 1);
 
 		{
-#ifdef USE_GETSET
-			T* hAbatch_ = new T[size_Abatch];
-#else
 			std::vector<T*> hAbatch_(size_Abatch, nullptr);
 			for (SizeType i = 0; i < size_Abatch; i++) {
 				hAbatch_[i] = &(pAbatch[i]);
 			}
-#endif
 
 			SizeType ipatch    = 0;
 			SizeType jpatch    = 0;
@@ -271,7 +267,7 @@ void setup_vbatch(
 								       ld1,
 								       ld2);
 								printf("ia=%lu, ja=%lu\n", ia, ja);
-							};
+							}
 
 							assert(m >= 1);
 							assert(n >= 1);
@@ -302,58 +298,32 @@ void setup_vbatch(
 										           < tiny)
 										    ? 0
 										    : 1;
-									};
-								};
+									}
+								}
 								nnz_A[ioperator - 1] += lnnz_A;
 
 								if (ipatch == jpatch) {
 									nnz_Adiag[ioperator - 1]
 									    += lnnz_A;
-								};
+								}
 
 								gnnz_A_[index3(ipatch,
 								               jpatch,
 								               ioperator,
 								               npatches)]
 								    = lnnz_A;
-							};
-						};
-					};
-				};
-			};
-
-#ifdef USE_GETSET
-			{
-				const SizeType incx = 1;
-				const SizeType incy = 1;
-
-				SizeType       n      = size_Abatch;
-				SizeType       istart = 1;
-				const SizeType nb     = 1024 * 1024 * 1024;
-
-				for (istart = 1; istart <= n; istart += nb) {
-					SizeType iend  = std::min(n, istart + nb - 1);
-					SizeType isize = (iend - istart + 1);
-					T*       src   = &(hAbatch_[istart - 1]);
-					T*       dest  = &(pAbatch[istart - 1]);
-
-					dmrg_Xsetvector(isize, src, incx, dest, incy);
-				};
+							}
+						}
+					}
+				}
 			}
-			delete[] hAbatch_;
-#endif
-		};
+		}
 
 		{
-#ifdef USE_GETSET
-
-			T* hBbatch_ = new T[size_Bbatch];
-#else
 			std::vector<T*> hBbatch_(size_Bbatch, nullptr);
 			for (SizeType i = 0; i < size_Bbatch; i++) {
 				hBbatch_[i] = &(pBbatch[i]);
 			}
-#endif
 
 			SizeType ioperator = 0;
 			for (ioperator = 1; ioperator <= noperator; ioperator++) {
@@ -409,46 +379,24 @@ void setup_vbatch(
 										           < tiny)
 										    ? 0
 										    : 1;
-									};
-								};
+									}
+								}
 								nnz_B[ioperator - 1] += lnnz_B;
 								if (ipatch == jpatch) {
 									nnz_Bdiag[ioperator - 1]
 									    += lnnz_B;
-								};
+								}
 								gnnz_B_[index3(ipatch,
 								               jpatch,
 								               ioperator,
 								               npatches)]
 								    = lnnz_B;
-							};
-						};
-					};
-				};
-			};
-
-#ifdef USE_GETSET
-			{
-				const SizeType incx = 1;
-				const SizeType incy = 1;
-
-				SizeType       n      = size_Bbatch;
-				SizeType       istart = 0;
-				const SizeType nb     = 1024 * 1024 * 1024;
-
-				for (istart = 1; istart <= n; istart += nb) {
-					SizeType iend  = std::min(n, istart + nb - 1);
-					SizeType isize = (iend - istart + 1);
-					T*       src   = &(hBbatch_[istart - 1]);
-					T*       dest  = &(pBbatch[istart - 1]);
-
-					dmrg_Xsetvector(isize, src, incx, dest, incy);
-				};
-			};
-
-			delete[] hBbatch_;
-#endif
-		};
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	if (idebug >= 1) {
@@ -476,7 +424,7 @@ void setup_vbatch(
 
 			assert(1 <= left_size);
 			assert(1 <= right_size);
-		};
+		}
 		assert(left_sum == left_max_state);
 		assert(right_sum == right_max_state);
 		(void)left_sum;
@@ -519,8 +467,8 @@ void setup_vbatch(
 				total_flops_method_1 += flops_method_1;
 				total_flops_method_2 += flops_method_2;
 				total_flops_min += std::min(flops_method_1, flops_method_2);
-			};
-		};
+			}
+		}
 		total_flops_method_1 *= ((double)noperator);
 		total_flops_method_2 *= ((double)noperator);
 		total_flops_min *= ((double)noperator);
@@ -551,8 +499,8 @@ void setup_vbatch(
 				       sparsity_ratio_B,
 				       fraction_in_diag_B);
 				printf(" \n");
-			};
-		};
+			}
+		}
 
 		printf("total_flops_method_1=%le (%6.2lf), ",
 		       total_flops_method_1,
@@ -576,14 +524,14 @@ void setup_vbatch(
 			          gnnz_A_,
 			          gnnz_B_);
 			icall++;
-		};
-	};
+		}
+	}
 
 	if (idebug >= 1) {
 		printf("setup_vbatch:memory Abatch (%f GBytes) Bbatch (%f GBytes)\n",
 		       (double)nbytes_Abatch / (giga),
 		       (double)nbytes_Bbatch / (giga));
-	};
+	}
 
 	pld_Abatch = ld_Abatch;
 	pld_Bbatch = ld_Bbatch;


### PR DESCRIPTION
Remove some unset macros and unused functions in GPUPlugin. I also removed some unnecessary semicolons that were bugging me.