### PR TITLE
Use Kokkos::Profiling::ScopedRegion in PsimagLite::Profiling

### DIFF
--- a/PsimagLite/src/PsimagLite/Profiling.h
+++ b/PsimagLite/src/PsimagLite/Profiling.h
@@ -41,7 +41,7 @@ public:
 	    , memoryUsage_("/proc/self/stat")
 	    , isDead_(false)
 	    , os_(os)
-	    , kokkos_region_(caller + ' ' + additional)
+	    , kokkos_region_(caller + (additional.empty() ? "" : (' ' + additional)))
 	{
 		OstringStream msg(std::cout.precision());
 		msg() << "starting clock " << additional;
@@ -49,16 +49,8 @@ public:
 	}
 
 	Profiling(String caller, std::ostream& os)
-	    : progressIndicator_(caller)
-	    , memoryUsage_("/proc/self/stat")
-	    , isDead_(false)
-	    , os_(os)
-	    , kokkos_region_(caller)
-	{
-		OstringStream msg(std::cout.precision());
-		msg() << "starting clock";
-		progressIndicator_.printline(msg, os);
-	}
+	    : Profiling(caller, {}, os)
+	{ }
 
 	Profiling(const Profiling&) = delete;
 

--- a/PsimagLite/src/PsimagLite/Profiling.h
+++ b/PsimagLite/src/PsimagLite/Profiling.h
@@ -23,6 +23,9 @@ Please see full open source license included in file LICENSE.
 #include "MemoryUsage.h"
 #include "ProgressIndicator.h"
 #include "PsimagLite.h"
+
+#include <Kokkos_Profiling_ScopedRegion.hpp>
+
 #include <iostream>
 
 namespace PsimagLite {
@@ -38,6 +41,7 @@ public:
 	    , memoryUsage_("/proc/self/stat")
 	    , isDead_(false)
 	    , os_(os)
+	    , kokkos_region_(caller + ' ' + additional)
 	{
 		OstringStream msg(std::cout.precision());
 		msg() << "starting clock " << additional;
@@ -49,12 +53,16 @@ public:
 	    , memoryUsage_("/proc/self/stat")
 	    , isDead_(false)
 	    , os_(os)
+	    , kokkos_region_(caller)
 	{
 		OstringStream msg(std::cout.precision());
 		msg() << "starting clock";
-		;
 		progressIndicator_.printline(msg, os);
 	}
+
+	Profiling(const Profiling&) = delete;
+
+	Profiling& operator=(const Profiling&) = delete;
 
 	~Profiling() { killIt(""); }
 
@@ -72,10 +80,11 @@ private:
 		isDead_ = true;
 	}
 
-	ProgressIndicator progressIndicator_;
-	MemoryUsage       memoryUsage_;
-	bool              isDead_;
-	std::ostream&     os_;
+	ProgressIndicator               progressIndicator_;
+	MemoryUsage                     memoryUsage_;
+	bool                            isDead_;
+	std::ostream&                   os_;
+	Kokkos::Profiling::ScopedRegion kokkos_region_;
 }; // Profiling
 } // namespace PsimagLite
 

--- a/dmrg/Engine/ModelBase.h
+++ b/dmrg/Engine/ModelBase.h
@@ -431,7 +431,7 @@ for (SizeType dof = 0; dof < numberOfDofs; ++dof) {
 	                              const LeftRightSuperType& lrs,
 	                              RealType                  currentTime) const
 	{
-		PsimagLite::Profiling profiling("addHamiltonianConnection", "", std::cout);
+		PsimagLite::Profiling profiling("addHamiltonianConnection", std::cout);
 
 		assert(lrs.super().partition() > 0);
 		SizeType total = lrs.super().partition() - 1;


### PR DESCRIPTION
Inspired by https://github.com/dmrgpp-project/dmrgpp/pull/285#issuecomment-5484625002.
Since `PsimagLite` already has a `Profiling` class, it makes sense to also use it for Kokkos Tools profiling.
Sample output with `342_batchedgemm`:
```
120: BEGIN KOKKOS PROFILING REPORT:
120: TOTAL TIME: 34.937221 seconds
120: TOP-DOWN TIME TREE:
120: <average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
120: ===================
120: |-> 3.32e+01 sec 94.9% 97.1% 0.0% 0.8% 5.30e+01 12 Diagonalization [region]
120: |   |-> 3.14e+01 sec 89.8% 100.0% 0.0% 0.0% 4.72e+01 247 BatchedGemmKokkos::matrixVector [region]
120: |   |   |-> 2.16e+01 sec 61.9% 100.0% 0.0% ------ 247 BatchedGemmKokkos_Pass1 [for]
120: |   |   |-> 9.68e+00 sec 27.7% 100.0% 0.0% ------ 247 BatchedGemmKokkos_Pass2 [for]
120: |   |   |-> 6.05e-02 sec 0.2% 100.0% 0.0% ------ 247 "d_flatBXbatch"="(none)" (HOST->HOST) [copy]
120: |   |-> 9.41e-01 sec 2.7% 90.3% 0.0% 0.0% 8.93e+01 12 BatchedGemmKokkos::setup [region]
120: |   |   |-> 8.85e-01 sec 2.5% 96.0% 0.0% 4.0% 1.36e+01 12 BatchedGemmKokkos::setup::gemm [region]
120: |   |   |   |-> 8.49e-01 sec 2.4% 100.0% 0.0% ------ 12 BatchedGemmKokkos::host_pack [for]
120: |   |   |-> 5.50e-02 sec 0.2% 0.0% 0.0% 100.0% 0.00e+00 12 BatchedGemmKokkos::setup::patch_pointers [region]
120: |   |-> 5.10e-01 sec 1.5% 0.0% 0.0% 100.0% 0.00e+00 12 convertXcYcArrays [region]
120: |   |-> 7.75e-02 sec 0.2% 0.0% 0.0% 35.1% 2.48e+03 9 WFT [region]
120: |       |-> 5.03e-02 sec 0.1% 0.0% 0.0% 0.5% 3.82e+03 192 PsimagLite::kokkos_gemm [region]
120: |           |-> 5.00e-02 sec 0.1% 0.0% 0.0% 100.0% 0.00e+00 192 KokkosBlas::gemm[TPL_BLAS,double] [region]
120: |-> 1.27e+00 sec 3.6% 0.0% 0.0% 100.0% 0.00e+00 15 addHamiltonianConnection [region]
120: |-> 3.93e-01 sec 1.1% 0.1% 0.0% 39.7% 2.02e+04 12 TruncationChangeBasis [region]
120: |   |-> 1.16e-01 sec 0.3% 0.0% 0.0% 100.0% 0.00e+00 15 DensityMatrixSvdDiag [region]
120: |   |-> 8.41e-02 sec 0.2% 0.4% 0.0% 5.4% 9.42e+04 7928 PsimagLite::kokkos_gemm [region]
120: |   |   |-> 7.80e-02 sec 0.2% 0.0% 0.0% 100.0% 0.00e+00 7492 KokkosBlas::gemm[TPL_BLAS,double] [region]
120: 
120: BOTTOM-UP TIME TREE:
120: <average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <number of calls> <name> [type]
120: ===================
120: |-> 2.16e+01 sec 61.9% 100.0% 0.0% ------ 247 BatchedGemmKokkos_Pass1 [for]
120: |   |-> 2.16e+01 sec 61.9% 100.0% 0.0% 0.0% 0.00e+00 247 BatchedGemmKokkos::matrixVector [region]
120: |       |-> 2.16e+01 sec 61.9% 100.0% 0.0% 0.0% 0.00e+00 247 Diagonalization [region]
120: |-> 9.68e+00 sec 27.7% 100.0% 0.0% ------ 247 BatchedGemmKokkos_Pass2 [for]
120: |   |-> 9.68e+00 sec 27.7% 100.0% 0.0% 0.0% 0.00e+00 247 BatchedGemmKokkos::matrixVector [region]
120: |       |-> 9.68e+00 sec 27.7% 100.0% 0.0% 0.0% 0.00e+00 247 Diagonalization [region]
120: |-> 1.27e+00 sec 3.6% 0.0% 0.0% 0.0% 0.00e+00 15 addHamiltonianConnection [region]
120: |-> 8.49e-01 sec 2.4% 100.0% 0.0% ------ 12 BatchedGemmKokkos::host_pack [for]
120: |   |-> 8.49e-01 sec 2.4% 100.0% 0.0% 0.0% 0.00e+00 12 BatchedGemmKokkos::setup::gemm [region]
120: |       |-> 8.49e-01 sec 2.4% 100.0% 0.0% 0.0% 0.00e+00 12 BatchedGemmKokkos::setup [region]
120: |           |-> 8.49e-01 sec 2.4% 100.0% 0.0% 0.0% 0.00e+00 12 Diagonalization [region]
120: |-> 5.10e-01 sec 1.5% 0.0% 0.0% 0.0% 0.00e+00 12 convertXcYcArrays [region]
120: |   |-> 5.10e-01 sec 1.5% 0.0% 0.0% 0.0% 0.00e+00 12 Diagonalization [region]
120: |-> 2.74e-01 sec 0.8% 0.0% 0.0% 0.0% 0.00e+00 12 Diagonalization [region]
120: |-> 1.56e-01 sec 0.4% 0.0% 0.0% 0.0% 0.00e+00 12 TruncationChangeBasis [region]
120: |-> 1.28e-01 sec 0.4% 0.0% 0.0% 0.0% 0.00e+00 7684 KokkosBlas::gemm[TPL_BLAS,double] [region]
120: |   |-> 1.28e-01 sec 0.4% 0.0% 0.0% 0.0% 0.00e+00 7684 PsimagLite::kokkos_gemm [region]
120: |       |-> 7.80e-02 sec 0.2% 0.0% 0.0% 0.0% 0.00e+00 7492 TruncationChangeBasis [region]
120: |       |-> 5.00e-02 sec 0.1% 0.0% 0.0% 0.0% 0.00e+00 192 WFT [region]
120: |           |-> 5.00e-02 sec 0.1% 0.0% 0.0% 0.0% 0.00e+00 192 Diagonalization [region]
120: |-> 1.16e-01 sec 0.3% 0.0% 0.0% 0.0% 0.00e+00 15 DensityMatrixSvdDiag [region]
120: |   |-> 1.16e-01 sec 0.3% 0.0% 0.0% 0.0% 0.00e+00 15 TruncationChangeBasis [region]
120: |-> 6.05e-02 sec 0.2% 100.0% 0.0% ------ 247 "d_flatBXbatch"="(none)" (HOST->HOST) [copy]
120: |   |-> 6.05e-02 sec 0.2% 100.0% 0.0% 0.0% 0.00e+00 247 BatchedGemmKokkos::matrixVector [region]
120: |       |-> 6.05e-02 sec 0.2% 100.0% 0.0% 0.0% 0.00e+00 247 Diagonalization [region]
120: |-> 5.50e-02 sec 0.2% 0.0% 0.0% 0.0% 0.00e+00 12 BatchedGemmKokkos::setup::patch_pointers [region]
120: |   |-> 5.50e-02 sec 0.2% 0.0% 0.0% 0.0% 0.00e+00 12 BatchedGemmKokkos::setup [region]
120: |       |-> 5.50e-02 sec 0.2% 0.0% 0.0% 0.0% 0.00e+00 12 Diagonalization [region]
120: |-> 3.55e-02 sec 0.1% 0.0% 0.0% 0.0% 0.00e+00 12 BatchedGemmKokkos::setup::gemm [region]
120: |   |-> 3.55e-02 sec 0.1% 0.0% 0.0% 0.0% 0.00e+00 12 BatchedGemmKokkos::setup [region]
120: |       |-> 3.55e-02 sec 0.1% 0.0% 0.0% 0.0% 0.00e+00 12 Diagonalization [region]
120: 
120: KOKKOS HOST SPACE:
120: ===================
120: MAX MEMORY ALLOCATED: 1266878.4 kB
120: ALLOCATIONS AT TIME OF HIGH WATER MARK:
120:   94.2% Diagonalization/BatchedGemmKokkos::setup/BatchedGemmKokkos::setup::intermediate/d_flatBbatch
120:   5.2% Diagonalization/BatchedGemmKokkos::setup/BatchedGemmKokkos::setup::intermediate/d_flatBXbatch
120:   0.5% Diagonalization/BatchedGemmKokkos::setup/BatchedGemmKokkos::setup::intermediate/d_flatAbatch
```