### PR TITLE
Fix centered chemical potential for PH bath fits

### DIFF
--- a/cincuenta/TestSuite/inputs/inputCincuenta0.ain
+++ b/cincuenta/TestSuite/inputs/inputCincuenta0.ain
@@ -1,9 +1,8 @@
 ##Ainur1.0
 
 FicticiousBeta=50;
-# Because we're using U nup ndown
-# the mu should be 0.5*U
-ChemicalPotential=4.;
+# ModelParams centers U*nup*ndown by placing -U/2 on the impurity.
+ChemicalPotential=0.;
 Matsubaras=400;
 # LatticeGf: 50 is the number of K points
 #LatticeGf="momentum,1D,50";

--- a/cincuenta/TestSuite/inputs/inputNeqGBEKFig3L3.ain
+++ b/cincuenta/TestSuite/inputs/inputNeqGBEKFig3L3.ain
@@ -11,7 +11,7 @@
 # Correlations expected to persist to t≈2.5 (vs t≈1.5 for L=2).
 
 FicticiousBeta=16;
-ChemicalPotential=1.;  # HubbardU/2, required by FitOptions=particleholesymmetric
+ChemicalPotential=0.;  # centered interaction; required by the PH-symmetric fit
 Matsubaras=200;
 LatticeGf="energy,semicircular,0.1";
 NumberOfBathPoints=5;

--- a/cincuenta/doc/cincuenta_design.md
+++ b/cincuenta/doc/cincuenta_design.md
@@ -150,11 +150,12 @@ zero-energy site for odd `nBath`).  This halves the number of free energy
 unknowns, making the fit better conditioned for half-filled, particle-hole
 symmetric models.
 
-When this is selected the
-chemical potential is required to be to U/2 (true for all LatticeGf or
-only semicircular?) Additionally `TargetElectronsUp + TargetElectronsDown ==
-NumberOfBathPoints + 1` (i.e., exactly half-filling of the full star-geometry
-system: must be specified.)
+`ModelParams` represents the interaction in centered form,
+`U n_up n_down - (U/2)(n_up+n_down)`, by placing `-U/2` on the impurity.
+Therefore this option requires `ChemicalPotential=0`; its bath energies are
+mirrored as `(epsilon,-epsilon)` around zero. Additionally,
+`TargetElectronsUp + TargetElectronsDown == NumberOfBathPoints + 1` is required
+(i.e., exactly half-filling of the full star-geometry system).
 
 ### Step 3 — Solve the impurity problem
 

--- a/cincuenta/src/DmftSolver.h
+++ b/cincuenta/src/DmftSolver.h
@@ -50,23 +50,17 @@ public:
 		else
 			err("Unknown impurity solver " + params.impuritySolver + "\n");
 
-		// FitOptions="particleholesymmetric" makes AndersonFunction fit mirror-image
-		// bath pairs (epsilon, -epsilon) about ChemicalPotential=; that bath is only
-		// the correct particle-hole-symmetric one if ChemicalPotential also sits at
-		// the impurity's actual particle-hole-symmetric point, which the solved
-		// impurity model fixes at U/2 (see ModelParams.h). A ChemicalPotential=
-		// away from U/2 would fit a symmetric-looking bath to the wrong target.
+		// ModelParams writes the interaction in centered form by placing -U/2 on
+		// the impurity: U*n_up*n_down - U/2*(n_up+n_down). Particle-hole symmetry
+		// is therefore at ChemicalPotential=0, and the constrained fit mirrors
+		// bath energies as (epsilon, -epsilon) around zero.
 		if (FitType::computeOptions(params.fit_options)
-		    == FitType::Options::PARTICLE_HOLE_SYMM) {
-			RealType U = 0;
-			io.readline(U, "HubbardU=");
-			const RealType muExpected = RealType(0.5) * U;
-			if (std::abs(params.mu - muExpected) > 1e-10)
-				err("DmftSolver: FitOptions=\"particleholesymmetric\" requires "
-				    "ChemicalPotential=HubbardU/2 ("
-				    + ttos(muExpected)
-				    + "); got ChemicalPotential=" + ttos(params.mu) + "\n");
-		}
+		        == FitType::Options::PARTICLE_HOLE_SYMM
+		    && std::abs(params.mu) > 1e-10)
+			err("DmftSolver: FitOptions=\"particleholesymmetric\" requires "
+			    "ChemicalPotential=0 for the centered impurity Hamiltonian; got "
+			    "ChemicalPotential="
+			    + ttos(params.mu) + "\n");
 	}
 
 	~DmftSolver()

--- a/cincuenta/src/tests/CMakeLists.txt
+++ b/cincuenta/src/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(test_Fit test_Fit.cpp)
 target_link_libraries(test_Fit PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)
-target_include_directories(test_Fit PRIVATE ${CMAKE_SOURCE_DIR}/cincuenta/src
-                                            ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+target_include_directories(test_Fit PRIVATE ${CMAKE_SOURCE_DIR}/cincuenta/src ${CMAKE_SOURCE_DIR}/dmrg/Engine)
 catch_discover_tests(test_Fit)
 
 add_executable(test_NeqBathDecomposition test_NeqBathDecomposition.cpp)

--- a/cincuenta/src/tests/CMakeLists.txt
+++ b/cincuenta/src/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+add_executable(test_Fit test_Fit.cpp)
+target_link_libraries(test_Fit PRIVATE Catch2::Catch2WithMain dmrgpp_utils psimaglite)
+target_include_directories(test_Fit PRIVATE ${CMAKE_SOURCE_DIR}/cincuenta/src
+                                            ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+catch_discover_tests(test_Fit)
+
 add_executable(test_NeqBathDecomposition test_NeqBathDecomposition.cpp)
 target_link_libraries(test_NeqBathDecomposition PRIVATE Catch2::Catch2WithMain psimaglite)
 target_include_directories(test_NeqBathDecomposition PRIVATE ${CMAKE_SOURCE_DIR}/cincuenta/src)

--- a/cincuenta/src/tests/test_Fit.cpp
+++ b/cincuenta/src/tests/test_Fit.cpp
@@ -1,0 +1,99 @@
+#include "Fit.h"
+#include "LatticeGf.h"
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <complex>
+#include <stdexcept>
+
+namespace {
+
+/**
+ * @brief Minimal readable configuration adapter for constructing `MinParams` in unit tests.
+ *
+ * `MinParams` accepts any duck-typed input object that provides `readline(value, label)`.
+ * This fixture supplies the fitting parameters used by `inputCincuenta0.ain` without
+ * requiring a complete Ainur input file or an `InputNg` parser. Each overload handles
+ * the value type requested by `MinParams`; unsupported labels throw because `MinParams`
+ * interprets that exception as "parameter not provided" and retains its default. In
+ * particular, rejecting `FitMethod=` selects the default
+ * conjugate-gradient method.
+ * Note there is both a FitMethod and a FitOption in play for fit and
+ * only FitMethod is part of DMFT::Fit's expectation for a minParams
+ * passed to it.
+ * Future tests of `Dmft::Fit` can reuse this pattern, adding supported labels only when
+ * the behavior under test requires values that differ from the production defaults.
+ */
+struct FitConfig {
+	void readline(double& value, const PsimagLite::String& label)
+	{
+		if (label == "MinParamsDelta=")
+			value = 0.1;
+		else if (label == "MinParamsDelta2=")
+			value = 0.01;
+		else if (label == "MinParamsTolerance=")
+			value = 1e-3;
+		else
+			throw std::runtime_error("unknown floating-point fit parameter");
+	}
+
+	void readline(SizeType& value, const PsimagLite::String& label)
+	{
+		if (label == "MinParamsMaxIter=")
+			value = 10000;
+		else
+			throw std::runtime_error("unknown integer fit parameter");
+	}
+
+	void readline(int& value, const PsimagLite::String& label)
+	{
+		if (label == "MinParamsVerbose=")
+			value = 0;
+		else
+			throw std::runtime_error("unknown integer fit parameter");
+	}
+
+	void readline(PsimagLite::String&, const PsimagLite::String&)
+	{
+		throw std::runtime_error("use the default fit method");
+	}
+};
+
+} // namespace
+
+TEST_CASE("centered PH fit produces a finite noncollapsed bath", "[Fit][particle-hole]")
+{
+	using ComplexType             = std::complex<double>;
+	using FunctionOfFrequencyType = Dmft::FunctionOfFrequency<ComplexType>;
+	using FitType                 = Dmft::Fit<ComplexType>;
+
+	constexpr SizeType           nBath = 5;
+	FunctionOfFrequencyType      sigma(/*fictitiousBeta=*/50.0, /*nMatsubara=*/400);
+	Dmft::LatticeGf<ComplexType> latticeGf(sigma, /*mu=*/0.0, "energy,semicircular,4");
+	latticeGf.update();
+
+	FitConfig                  config;
+	FitType::MinParamsType     minParams(config);
+	const FitType::InitResults initialBath(/*ra=*/1.0, /*rb=*/0.0, {}, /*reset=*/false);
+	FitType                    fit(nBath, minParams, initialBath);
+	fit.fit(latticeGf.g0(), /*mu=*/0.0, FitType::Options::PARTICLE_HOLE_SYMM);
+
+	const auto& bath = fit.result();
+	REQUIRE(bath.size() == 2 * nBath);
+	for (const double value : bath)
+		REQUIRE(std::isfinite(value));
+
+	const auto hopping = [&bath](SizeType i) { return bath[i]; };
+	const auto energy  = [&bath](SizeType i) { return bath[nBath + i]; };
+
+	CHECK(hopping(3) == hopping(0));
+	CHECK(hopping(4) == hopping(1));
+	CHECK(energy(2) == 0.0);
+	CHECK(energy(3) == -energy(0));
+	CHECK(energy(4) == -energy(1));
+
+	double maxHybridization = 0.0;
+	for (SizeType i = 0; i < nBath; ++i)
+		maxHybridization = std::max(maxHybridization, std::abs(hopping(i)));
+	CHECK(maxHybridization > 1e-6);
+}


### PR DESCRIPTION
I made a previous inconsistency (which only related to a comment) with the treatment of the impurity potential and the chemical potential worse (i.e. made it a real bug) in a recent PR. This fixes that inconsistency and we now properly treat the centered representation with an impurity potential of U/2 and chemical potential = 0 once more with an added unit test and no misleading documenting comments. 