### PR TITLE
Fix Kokkos dependency pairing in CMake

### DIFF
--- a/PsimagLite/src/CMakeLists.txt
+++ b/PsimagLite/src/CMakeLists.txt
@@ -16,35 +16,43 @@ add_library(
   PsimagLite/Ainur/AinurSpirit.cpp
   PsimagLite/Ainur/AinurConvert.cpp)
 
-# Ensure Kokkos and KokkosKernels are available
+# Resolve Kokkos and KokkosKernels as a coherent pair. An installed
+# KokkosKernels package must be considered before a Kokkos target exists so its
+# package configuration can select the Kokkos installation it was built with.
 include(FetchContent)
-list(APPEND CMAKE_MESSAGE_INDENT "[Kokkos] ")
-FetchContent_Declare(
-  Kokkos
-  GIT_REPOSITORY https://github.com/kokkos/kokkos
-  GIT_TAG 5.2.0
-  SYSTEM FIND_PACKAGE_ARGS 5.1 NAMES Kokkos)
-FetchContent_MakeAvailable(Kokkos)
-list(POP_BACK CMAKE_MESSAGE_INDENT)
 
-list(APPEND CMAKE_MESSAGE_INDENT "[KokkosKernels] ")
-FetchContent_Declare(
-  KokkosKernels
-  GIT_REPOSITORY https://github.com/kokkos/kokkos-kernels
-  GIT_TAG 5.2.0
-  SYSTEM FIND_PACKAGE_ARGS 5.1 NAMES KokkosKernels)
-# Since DRMGPP requires BLAS and LAPACK, we should also make sure KokkosKernels uses these as TPLs
-set(KokkosKernels_ENABLE_TPL_BLAS
-    ON
-    CACHE BOOL "Whether to enable the BLAS TPL" FORCE)
-set(KokkosKernels_ENABLE_TPL_LAPACK
-    ON
-    CACHE BOOL "Whether to enable the LAPACK TPL" FORCE)
-FetchContent_MakeAvailable(KokkosKernels)
-if(NOT KokkosKernels_POPULATED)
+if(TARGET Kokkos::kokkoskernels)
+  message(
+    FATAL_ERROR
+      "A pre-existing Kokkos::kokkoskernels target cannot be verified as coherent with Kokkos::kokkos; let DMRG++ resolve the pair"
+  )
+endif()
+
+set(_dmrgpp_probe_kokkoskernels TRUE)
+if(FETCHCONTENT_TRY_FIND_PACKAGE_MODE STREQUAL "NEVER"
+   OR FETCHCONTENT_SOURCE_DIR_KOKKOS
+   OR FETCHCONTENT_SOURCE_DIR_KOKKOSKERNELS
+   OR TARGET Kokkos::kokkos)
+  set(_dmrgpp_probe_kokkoskernels FALSE)
+endif()
+
+if(_dmrgpp_probe_kokkoskernels)
+  list(APPEND CMAKE_MESSAGE_INDENT "[KokkosKernels] ")
+  find_package(KokkosKernels 5.1 QUIET CONFIG NAMES KokkosKernels)
+  list(POP_BACK CMAKE_MESSAGE_INDENT)
+endif()
+
+if(KokkosKernels_FOUND)
+  if(NOT TARGET Kokkos::kokkos OR NOT TARGET Kokkos::kokkoskernels)
+    message(FATAL_ERROR "The KokkosKernels package did not provide both Kokkos::kokkos and Kokkos::kokkoskernels")
+  endif()
+  set(_dmrgpp_kokkos_provenance "package via KokkosKernels")
+  set(_dmrgpp_kokkoskernels_provenance "package")
+
+  # Remove values forced for a source build by an earlier configure. Newer
+  # installed packages export these as normal variables that can be checked.
   unset(KokkosKernels_ENABLE_TPL_BLAS CACHE)
   unset(KokkosKernels_ENABLE_TPL_LAPACK CACHE)
-  # Past version 5.2, KokkosKernels exports its TPLs as non-CACHE variables
   if(KokkosKernels_VERSION VERSION_GREATER_EQUAL 5.2.99)
     if(NOT KokkosKernels_ENABLE_TPL_BLAS)
       message(FATAL_ERROR "KokkosKernels must be configured with BLAS support!")
@@ -53,8 +61,72 @@ if(NOT KokkosKernels_POPULATED)
       message(FATAL_ERROR "KokkosKernels must be configured with LAPACK support!")
     endif()
   endif()
+else()
+  # No installed pair was selected. Resolve Kokkos on its own, then always
+  # build KokkosKernels against that selected target. Package discovery for
+  # KokkosKernels is disabled so an installed library cannot be substituted.
+  if(TARGET Kokkos::kokkos)
+    set(_dmrgpp_kokkos_provenance "provided")
+  else()
+    list(APPEND CMAKE_MESSAGE_INDENT "[Kokkos] ")
+    FetchContent_Declare(
+      Kokkos
+      GIT_REPOSITORY https://github.com/kokkos/kokkos
+      GIT_TAG 5.2.0
+      SYSTEM FIND_PACKAGE_ARGS 5.1 NAMES Kokkos)
+    FetchContent_MakeAvailable(Kokkos)
+    FetchContent_GetProperties(Kokkos SOURCE_DIR _dmrgpp_kokkos_source_dir)
+    list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+    if(NOT TARGET Kokkos::kokkos)
+      message(FATAL_ERROR "Kokkos did not provide the required Kokkos::kokkos target")
+    endif()
+    if(_dmrgpp_kokkos_source_dir)
+      set(_dmrgpp_kokkos_provenance "source")
+    else()
+      set(_dmrgpp_kokkos_provenance "package or provider")
+    endif()
+  endif()
+
+  # Since DMRG++ requires BLAS and LAPACK, require the source build to use both
+  # as TPLs.
+  set(KokkosKernels_ENABLE_TPL_BLAS
+      ON
+      CACHE BOOL "Whether to enable the BLAS TPL" FORCE)
+  set(KokkosKernels_ENABLE_TPL_LAPACK
+      ON
+      CACHE BOOL "Whether to enable the LAPACK TPL" FORCE)
+  list(APPEND CMAKE_MESSAGE_INDENT "[KokkosKernels] ")
+  block()
+  set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
+  FetchContent_Declare(
+    KokkosKernels
+    GIT_REPOSITORY https://github.com/kokkos/kokkos-kernels
+    GIT_TAG 5.2.0
+    SYSTEM)
+  endblock()
+  FetchContent_MakeAvailable(KokkosKernels)
+  FetchContent_GetProperties(KokkosKernels SOURCE_DIR _dmrgpp_kokkoskernels_source_dir)
+  list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+  if(NOT TARGET Kokkos::kokkoskernels)
+    message(FATAL_ERROR "KokkosKernels did not provide the required Kokkos::kokkoskernels target")
+  endif()
+  if(_dmrgpp_kokkoskernels_source_dir)
+    set(_dmrgpp_kokkoskernels_provenance "source")
+  else()
+    set(_dmrgpp_kokkoskernels_provenance "provider")
+  endif()
 endif()
-list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+set(DMRGPP_KOKKOS_PROVENANCE
+    "${_dmrgpp_kokkos_provenance}"
+    CACHE INTERNAL "How Kokkos was resolved" FORCE)
+set(DMRGPP_KOKKOSKERNELS_PROVENANCE
+    "${_dmrgpp_kokkoskernels_provenance}"
+    CACHE INTERNAL "How KokkosKernels was resolved" FORCE)
+message(
+  STATUS "Kokkos dependency pair: Kokkos=${DMRGPP_KOKKOS_PROVENANCE}, KokkosKernels=${DMRGPP_KOKKOSKERNELS_PROVENANCE}")
 
 target_link_libraries(psimaglite PUBLIC Kokkos::kokkoskernels Kokkos::kokkos)
 target_sources(psimaglite PRIVATE PsimagLite/KokkosGemm.cpp)


### PR DESCRIPTION
  ## Summary

   Prevent CMake from combining a fetched Kokkos runtime with an installed
   KokkosKernels package built against a different Kokkos installation.  This happened to me 
   repeatedly with my own spack environments so we probably should cover this corner case,
   it seems like a user could hit it as well.

   ## Problem

   DMRG++ previously resolved Kokkos before KokkosKernels. If standalone Kokkos
   package discovery failed, CMake fetched Kokkos and created `Kokkos::kokkos`.
   A subsequent installed KokkosKernels package could then accept that existing
   target instead of loading the Kokkos installation against which it was built.

   This produced an executable containing both a fetched static Kokkos runtime and
   the shared Kokkos runtime required by KokkosKernels. The mixed Kokkos runtimes caused an 
   exit-time double-free during direct single-process execution. The failure was not reproduced under
   mpiexec -n 1, although the invalid runtime combination remained present.

   ## Changes

   - Probe for an installed KokkosKernels package before creating a standalone
     Kokkos target, allowing its package configuration to load its matching Kokkos.
   - If no installed pair is selected:
     - resolve Kokkos through the existing package/provider/FetchContent logic;
     - build KokkosKernels against that selected Kokkos target;
     - prevent an unrelated installed KokkosKernels package from being substituted.
   - Reject a pre-existing KokkosKernels target whose pairing cannot be verified.
   - Preserve the required BLAS and LAPACK options and installed-package checks.
   - Record Kokkos and KokkosKernels provenance in the CMake cache and configure
     output for diagnostics.
   - Preserve FetchContent providers, source overrides, disconnected operation,
     and fully fetched builds without hard-coded installation paths.

   ## Validation

   Validated the following configurations:

   - Installed KokkosKernels with its matching installed Kokkos.
   - Fully fetched Kokkos and KokkosKernels.
   - Installed Kokkos with source-built KokkosKernels.
   - Explicit KokkosKernels source override.

   For the installed pair, the Cincuenta link and runtime dependencies contain
   only the matching shared Kokkos/KokkosKernels installation; the fetched static
   Kokkos library is no longer present.

   For the fully fetched configuration, the executable uses only libraries from
   the corresponding FetchContent builds.

   The following checks also passed:

   - MPI-enabled Cincuenta build.
   - Direct `cincuenta -V`.
   - Direct `inputCincuenta0.ain` calculation.
   - `mpiexec -n 1` control run.
   - `ctest -R '^cincuenta0$'`.

This PR was prepared with the help of GPT-5.6-sol and terra.