### PR TITLE
MatrixVector PR Series Part I: Simplify template

### DIFF
--- a/dmrg/Engine/DmrgRunner.cpp
+++ b/dmrg/Engine/DmrgRunner.cpp
@@ -94,7 +94,7 @@ void DmrgRunner<RealType>::doOneRun2(const OptionsForIntrospect& op_options) con
 	                                         InputNgType::Readable,
 	                                         SuperGeometryType>;
 	using MatrixVectorModelType  = typename MatrixVectorTypes<ComplexOrRealType>::ModelType;
-	static_assert(std::is_same<ModelBaseType, MatrixVectorModelType>::value,
+	static_assert(std::is_same_v<ModelBaseType, MatrixVectorModelType>,
 	              "DmrgRunner and MatrixVectorTypes must use the same model type");
 
 	assert(dmrg_solver_params_);

--- a/dmrg/Engine/DmrgRunner.cpp
+++ b/dmrg/Engine/DmrgRunner.cpp
@@ -1,4 +1,6 @@
 #include "DmrgRunner.h"
+#include "MatrixVectorTypes.hpp"
+#include <type_traits>
 
 namespace Dmrg {
 
@@ -91,14 +93,17 @@ void DmrgRunner<RealType>::doOneRun2(const OptionsForIntrospect& op_options) con
 	                                         ParametersDmrgSolverType,
 	                                         InputNgType::Readable,
 	                                         SuperGeometryType>;
+	using MatrixVectorModelType  = typename MatrixVectorTypes<ComplexOrRealType>::ModelType;
+	static_assert(std::is_same<ModelBaseType, MatrixVectorModelType>::value,
+	              "DmrgRunner and MatrixVectorTypes must use the same model type");
 
 	assert(dmrg_solver_params_);
 	if (dmrg_solver_params_->options.isSet("MatrixVectorStored")) {
-		doOneRun3<MatrixVectorStored<ModelBaseType>>(op_options);
+		doOneRun3<MatrixVectorStored<ComplexOrRealType>>(op_options);
 	} else if (dmrg_solver_params_->options.isSet("MatrixVectorOnTheFly")) {
-		doOneRun3<MatrixVectorOnTheFly<ModelBaseType>>(op_options);
+		doOneRun3<MatrixVectorOnTheFly<ComplexOrRealType>>(op_options);
 	} else {
-		doOneRun3<MatrixVectorKron<ModelBaseType>>(op_options);
+		doOneRun3<MatrixVectorKron<ComplexOrRealType>>(op_options);
 	}
 }
 

--- a/dmrg/Engine/MatrixVectorBase.h
+++ b/dmrg/Engine/MatrixVectorBase.h
@@ -80,19 +80,21 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #ifndef DMRG_MATRIX_VECTOR_BASE_H
 #define DMRG_MATRIX_VECTOR_BASE_H
 
+#include "MatrixVectorTypes.hpp"
 #include <PsimagLite/PsimagLite.h>
 #include <vector>
 
 namespace Dmrg {
-template <typename ModelType_> class MatrixVectorBase {
+template <typename ComplexOrRealType_> class MatrixVectorBase {
 
 public:
 
-	using ModelType         = ModelType_;
-	using ModelHelperType   = typename ModelType::ModelHelperType;
-	using RealType          = typename ModelHelperType::RealType;
-	using SparseMatrixType  = typename ModelHelperType::SparseMatrixType;
-	using ComplexOrRealType = typename SparseMatrixType::value_type;
+	using TypesType         = MatrixVectorTypes<ComplexOrRealType_>;
+	using ModelType         = typename TypesType::ModelType;
+	using ModelHelperType   = typename TypesType::ModelHelperType;
+	using RealType          = typename TypesType::RealType;
+	using SparseMatrixType  = typename TypesType::SparseMatrixType;
+	using ComplexOrRealType = ComplexOrRealType_;
 	using VectorRealType    = typename PsimagLite::Vector<RealType>::Type;
 	using VectorType        = typename PsimagLite::Vector<ComplexOrRealType>::Type;
 	using FullMatrixType    = PsimagLite::Matrix<ComplexOrRealType>;

--- a/dmrg/Engine/MatrixVectorKron/MatrixVectorKron.h
+++ b/dmrg/Engine/MatrixVectorKron/MatrixVectorKron.h
@@ -86,22 +86,23 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include <PsimagLite/Vector.h>
 
 namespace Dmrg {
-template <typename ModelType_> class MatrixVectorKron : public MatrixVectorBase<ModelType_> {
+template <typename ComplexOrRealType_>
+class MatrixVectorKron : public MatrixVectorBase<ComplexOrRealType_> {
 
-	using BaseType = MatrixVectorBase<ModelType_>;
+	using BaseType = MatrixVectorBase<ComplexOrRealType_>;
 
 	static const bool CHECK_KRON = true;
 
 public:
 
-	using ModelType                 = ModelType_;
+	using ModelType                 = typename BaseType::ModelType;
 	using ModelHelperType           = typename ModelType::ModelHelperType;
 	using ParametersType            = typename ModelType::ParametersType;
 	using RealType                  = typename ModelHelperType::RealType;
 	using InitKronType              = InitKronHamiltonian<ModelType>;
 	using KronMatrixType            = KronMatrix<InitKronType>;
 	using SparseMatrixType          = typename ModelHelperType::SparseMatrixType;
-	using ComplexOrRealType         = typename SparseMatrixType::value_type;
+	using ComplexOrRealType         = ComplexOrRealType_;
 	using VectorRealType            = typename PsimagLite::Vector<RealType>::Type;
 	using VectorType                = typename PsimagLite::Vector<ComplexOrRealType>::Type;
 	using FullMatrixType            = PsimagLite::Matrix<ComplexOrRealType>;

--- a/dmrg/Engine/MatrixVectorOnTheFly.h
+++ b/dmrg/Engine/MatrixVectorOnTheFly.h
@@ -84,18 +84,19 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include <vector>
 
 namespace Dmrg {
-template <typename ModelType_> class MatrixVectorOnTheFly : public MatrixVectorBase<ModelType_> {
+template <typename ComplexOrRealType_>
+class MatrixVectorOnTheFly : public MatrixVectorBase<ComplexOrRealType_> {
 
-	using BaseType = MatrixVectorBase<ModelType_>;
+	using BaseType = MatrixVectorBase<ComplexOrRealType_>;
 
 public:
 
-	using ModelType                 = ModelType_;
+	using ModelType                 = typename BaseType::ModelType;
 	using ModelHelperType           = typename ModelType::ModelHelperType;
 	using RealType                  = typename ModelHelperType::RealType;
 	using SparseMatrixType          = typename ModelHelperType::SparseMatrixType;
 	using value_type                = typename SparseMatrixType::value_type;
-	using ComplexOrRealType         = typename SparseMatrixType::value_type;
+	using ComplexOrRealType         = ComplexOrRealType_;
 	using VectorRealType            = typename PsimagLite::Vector<RealType>::Type;
 	using FullMatrixType            = PsimagLite::Matrix<ComplexOrRealType>;
 	using HamiltonianConnectionType = typename ModelType::HamiltonianConnectionType;

--- a/dmrg/Engine/MatrixVectorStored.h
+++ b/dmrg/Engine/MatrixVectorStored.h
@@ -85,20 +85,21 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include <vector>
 
 namespace Dmrg {
-template <typename ModelType_> class MatrixVectorStored : public MatrixVectorBase<ModelType_> {
+template <typename ComplexOrRealType_>
+class MatrixVectorStored : public MatrixVectorBase<ComplexOrRealType_> {
 
-	using BaseType = MatrixVectorBase<ModelType_>;
+	using BaseType = MatrixVectorBase<ComplexOrRealType_>;
 
 public:
 
-	using ModelType                 = ModelType_;
+	using ModelType                 = typename BaseType::ModelType;
 	using HamiltonianConnectionType = typename ModelType::HamiltonianConnectionType;
 	using ParametersType            = typename ModelType::ParametersType;
 	using ModelHelperType           = typename ModelType::ModelHelperType;
 	using SparseMatrixType          = typename ModelHelperType::SparseMatrixType;
 	using RealType                  = typename ModelHelperType::RealType;
 	using value_type                = typename SparseMatrixType::value_type;
-	using ComplexOrRealType         = typename SparseMatrixType::value_type;
+	using ComplexOrRealType         = ComplexOrRealType_;
 	using VectorRealType            = typename PsimagLite::Vector<RealType>::Type;
 	using OptionsType               = typename ParametersType::OptionsType;
 	using FullMatrixType            = PsimagLite::Matrix<ComplexOrRealType>;

--- a/dmrg/Engine/MatrixVectorTypes.hpp
+++ b/dmrg/Engine/MatrixVectorTypes.hpp
@@ -17,21 +17,18 @@ namespace Dmrg {
 
 template <typename ComplexOrRealType_> struct MatrixVectorTypes {
 
-	using ComplexOrRealType         = ComplexOrRealType_;
-	using InputNgType               = PsimagLite::InputNg<InputCheck>;
-	using InputType                 = typename InputNgType::Readable;
-	using SparseMatrixType          = PsimagLite::CrsMatrix<ComplexOrRealType>;
-	using BasisType                 = Basis<SparseMatrixType>;
-	using RealType                  = typename BasisType::RealType;
-	using BasisWithOperatorsType    = BasisWithOperators<BasisType>;
-	using LeftRightSuperType        = LeftRightSuper<BasisWithOperatorsType, BasisType>;
-	using ModelHelperType           = ModelHelperLocal<LeftRightSuperType>;
-	using ParametersType            = ParametersDmrgSolver<RealType, InputType, Qn>;
-	using SuperGeometryType         = SuperGeometry<ComplexOrRealType, InputType, ProgramGlobals>;
-	using ModelType = ModelBase<ModelHelperType,
-	                            ParametersType,
-	                            InputType,
-	                            SuperGeometryType>;
+	using ComplexOrRealType      = ComplexOrRealType_;
+	using InputNgType            = PsimagLite::InputNg<InputCheck>;
+	using InputType              = typename InputNgType::Readable;
+	using SparseMatrixType       = PsimagLite::CrsMatrix<ComplexOrRealType>;
+	using BasisType              = Basis<SparseMatrixType>;
+	using RealType               = typename BasisType::RealType;
+	using BasisWithOperatorsType = BasisWithOperators<BasisType>;
+	using LeftRightSuperType     = LeftRightSuper<BasisWithOperatorsType, BasisType>;
+	using ModelHelperType        = ModelHelperLocal<LeftRightSuperType>;
+	using ParametersType         = ParametersDmrgSolver<RealType, InputType, Qn>;
+	using SuperGeometryType      = SuperGeometry<ComplexOrRealType, InputType, ProgramGlobals>;
+	using ModelType = ModelBase<ModelHelperType, ParametersType, InputType, SuperGeometryType>;
 	using HamiltonianConnectionType = typename ModelType::HamiltonianConnectionType;
 };
 

--- a/dmrg/Engine/MatrixVectorTypes.hpp
+++ b/dmrg/Engine/MatrixVectorTypes.hpp
@@ -1,0 +1,40 @@
+#ifndef MATRIX_VECTOR_TYPES_HPP
+#define MATRIX_VECTOR_TYPES_HPP
+
+#include "Basis.h"
+#include "BasisWithOperators.h"
+#include "InputCheck.h"
+#include "LeftRightSuper.h"
+#include "ModelBase.h"
+#include "ModelHelperLocal.h"
+#include "ParametersDmrgSolver.h"
+#include "Qn.h"
+#include "SuperGeometry.h"
+#include <PsimagLite/CrsMatrix.h>
+#include <PsimagLite/InputNg.h>
+
+namespace Dmrg {
+
+template <typename ComplexOrRealType_> struct MatrixVectorTypes {
+
+	using ComplexOrRealType         = ComplexOrRealType_;
+	using InputNgType               = PsimagLite::InputNg<InputCheck>;
+	using InputType                 = typename InputNgType::Readable;
+	using SparseMatrixType          = PsimagLite::CrsMatrix<ComplexOrRealType>;
+	using BasisType                 = Basis<SparseMatrixType>;
+	using RealType                  = typename BasisType::RealType;
+	using BasisWithOperatorsType    = BasisWithOperators<BasisType>;
+	using LeftRightSuperType        = LeftRightSuper<BasisWithOperatorsType, BasisType>;
+	using ModelHelperType           = ModelHelperLocal<LeftRightSuperType>;
+	using ParametersType            = ParametersDmrgSolver<RealType, InputType, Qn>;
+	using SuperGeometryType         = SuperGeometry<ComplexOrRealType, InputType, ProgramGlobals>;
+	using ModelType = ModelBase<ModelHelperType,
+	                            ParametersType,
+	                            InputType,
+	                            SuperGeometryType>;
+	using HamiltonianConnectionType = typename ModelType::HamiltonianConnectionType;
+};
+
+} // namespace Dmrg
+
+#endif // MATRIX_VECTOR_TYPES_HPP


### PR DESCRIPTION
This is part of a PR series to make MatrixVector hierarchy go from templated to virtual inheritance. It'll lower compilation times but also it'll make it easier to fit planned features.

Part I: Changes the ModelType template of ``MatrixVectorBase<ModelType>`` into ``MatrixVectorBase<ComplexOrRealType>`` (and for all derived classes).

Note that the intention is for ComplexOrRealType to take only double or std::complex<double>, but that's not enforced with a static_assert or anything. In any case, executables like dmrg and observe and cincuenta do instantiate both types and the exec. path is chosen at runtime from the input.