### PR TITLE
clang-tidy: Ensure correct override annotation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: >
+  -*,
+  modernize-use-override

--- a/LanczosPlusPlus/src/Models/FeBasedSc/BasisFeAsBasedSc.h
+++ b/LanczosPlusPlus/src/Models/FeBasedSc/BasisFeAsBasedSc.h
@@ -51,35 +51,35 @@ public:
 	    , basis2_(geometry.numberOfSites(), ndown, orbitals)
 	{ }
 
-	PairIntType parts() const { return PairIntType(nup_, ndown_); }
+	PairIntType parts() const override { return PairIntType(nup_, ndown_); }
 
 	static const WordType& bitmask(SizeType i) { return BasisType::bitmask(i); }
 
-	SizeType dofs() const { return 2 * orbitals_; }
+	SizeType dofs() const override { return 2 * orbitals_; }
 
-	SizeType size() const { return basis1_.size() * basis2_.size(); }
+	SizeType size() const override { return basis1_.size() * basis2_.size(); }
 
-	virtual SizeType hilbertOneSite(SizeType) const { return (1 << (orbitals_ * 2)); }
+	SizeType hilbertOneSite(SizeType) const override { return (1 << (orbitals_ * 2)); }
 
-	WordType operator()(SizeType i, SizeType spin) const
+	WordType operator()(SizeType i, SizeType spin) const override
 	{
 		SizeType y = i / basis1_.size();
 		SizeType x = i % basis1_.size();
 		return (spin == SPIN_UP) ? basis1_[x] : basis2_[y];
 	}
 
-	SizeType perfectIndex(const VectorWordType& kets) const
+	SizeType perfectIndex(const VectorWordType& kets) const override
 	{
 		assert(kets.size() == 2);
 		return perfectIndex(kets[0], kets[1]);
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType ket2) const
+	SizeType perfectIndex(WordType ket1, WordType ket2) const override
 	{
 		return basis1_.perfectIndex(ket1) + basis2_.perfectIndex(ket2) * basis1_.size();
 	}
 
-	SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("perfectIndex\n");
 	}
@@ -91,8 +91,11 @@ public:
 		return (spin == SPIN_UP) ? basis1_.getN(x, orb) : basis2_.getN(y, orb);
 	}
 
-	SizeType
-	getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType orb) const
+	SizeType getN(WordType ket1,
+	              WordType ket2,
+	              SizeType site,
+	              SizeType spin,
+	              SizeType orb) const override
 	{
 		return (spin == SPIN_UP) ? basis1_.getN(ket1, site, orb)
 		                         : basis2_.getN(ket2, site, orb);
@@ -103,7 +106,7 @@ public:
 	                        const LabeledOperatorType& lOperator,
 	                        SizeType                   site,
 	                        SizeType                   spin,
-	                        SizeType                   orb) const
+	                        SizeType                   orb) const override
 	{
 		if (lOperator.id() == LabeledOperatorType::Label::OPERATOR_C
 		    || lOperator.id() == LabeledOperatorType::Label::OPERATOR_CDAGGER
@@ -132,7 +135,7 @@ public:
 	           SizeType orb1,
 	           SizeType j,
 	           SizeType orb2,
-	           SizeType spin) const
+	           SizeType spin) const override
 	{
 		if (i > j) {
 			std::cerr << "FATAL: At doSign\n";
@@ -146,7 +149,8 @@ public:
 		return basis2_.doSign(ket2, i, orb1, j, orb2);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		if (spin == SPIN_UP)
 			return basis1_.doSignGf(a, ind, orb);
@@ -180,7 +184,8 @@ public:
 		return x * s * basis1_.doSignGf(a, ind, orb1) * basis2_.doSignGf(b, ind, orb2);
 	}
 
-	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		if (spin == SPIN_UP) { // spin here means S^\dagger
 			// FIXME: Count over a (up)
@@ -195,7 +200,7 @@ public:
 	                             WordType ket2,
 	                             SizeType site,
 	                             SizeType spin,
-	                             SizeType orb) const
+	                             SizeType orb) const override
 	{
 		if (spin == SPIN_UP)
 			return basis1_.isThereAnElectronAt(ket1, site, orb);
@@ -223,11 +228,14 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	SizeType orbsPerSite(SizeType) const { throw PsimagLite::RuntimeError("orbsPerSite\n"); }
+	SizeType orbsPerSite(SizeType) const override
+	{
+		throw PsimagLite::RuntimeError("orbsPerSite\n");
+	}
 
-	SizeType orbs() const { throw PsimagLite::RuntimeError("orbs\n"); }
+	SizeType orbs() const override { throw PsimagLite::RuntimeError("orbs\n"); }
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		bool isBinary = (binaryOrDecimal == BaseType::PRINT_BINARY);
 		os << "\tUp sector\n";
@@ -236,8 +244,8 @@ public:
 		basis2_.print(os, isBinary);
 	}
 
-	virtual bool
-	getBra(WordType&, WordType, WordType, const LabeledOperatorType&, SizeType, SizeType) const
+	bool getBra(WordType&, WordType, WordType, const LabeledOperatorType&, SizeType, SizeType)
+	    const override
 	{
 		throw PsimagLite::RuntimeError("BasisFeAs: getBra\n");
 	}

--- a/LanczosPlusPlus/src/Models/FeBasedSc/BasisFeAsSpinOrbit.h
+++ b/LanczosPlusPlus/src/Models/FeBasedSc/BasisFeAsSpinOrbit.h
@@ -66,39 +66,42 @@ public:
 		}
 	}
 
-	PairIntType parts() const { return PairIntType(nup_, ndown_); }
+	PairIntType parts() const override { return PairIntType(nup_, ndown_); }
 
 	static const WordType& bitmask(SizeType i) { return BasisOneSpinType::bitmask(i); }
 
-	SizeType dofs() const { return 2 * orbitals_; }
+	SizeType dofs() const override { return 2 * orbitals_; }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	virtual SizeType hilbertOneSite(SizeType) const { return (1 << (orbitals_ * 2)); }
+	SizeType hilbertOneSite(SizeType) const override { return (1 << (orbitals_ * 2)); }
 
-	WordType operator()(SizeType i, SizeType spin) const
+	WordType operator()(SizeType i, SizeType spin) const override
 	{
 		return (spin == SPIN_UP) ? basis_[i].first : basis_[i].second;
 	}
 
-	SizeType perfectIndex(const VectorWordType& kets) const
+	SizeType perfectIndex(const VectorWordType& kets) const override
 	{
 		assert(kets.size() == 2);
 		return perfectIndex(kets[0], kets[1]);
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType ket2) const
+	SizeType perfectIndex(WordType ket1, WordType ket2) const override
 	{
 		return reverse_[PairWordType(ket1, ket2)];
 	}
 
-	SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("perfectIndex\n");
 	}
 
-	SizeType
-	getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType orb) const
+	SizeType getN(WordType ket1,
+	              WordType ket2,
+	              SizeType site,
+	              SizeType spin,
+	              SizeType orb) const override
 	{
 		return (spin == SPIN_UP) ? basis1_.getN(ket1, site, orb)
 		                         : basis1_.getN(ket2, site, orb);
@@ -109,7 +112,7 @@ public:
 	                        const LabeledOperatorType& lOperator,
 	                        SizeType                   site,
 	                        SizeType                   spin,
-	                        SizeType                   orb) const
+	                        SizeType                   orb) const override
 	{
 		if (lOperator.id() == LabeledOperatorType::Label::OPERATOR_C
 		    || lOperator.id() == LabeledOperatorType::Label::OPERATOR_CDAGGER
@@ -135,7 +138,7 @@ public:
 	           SizeType orb1,
 	           SizeType j,
 	           SizeType orb2,
-	           SizeType spin) const
+	           SizeType spin) const override
 	{
 		if (i > j) {
 			std::cerr << "FATAL: At doSign\n";
@@ -148,7 +151,8 @@ public:
 		                         : basis1_.doSign(ket2, i, orb1, j, orb2);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		if (spin == SPIN_UP)
 			return basis1_.doSignGf(a, ind, orb);
@@ -183,7 +187,8 @@ public:
 		return x * s * basis1_.doSignGf(a, ind, orb2) * basis1_.doSignGf(b, ind, orb1);
 	}
 
-	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		if (spin == SPIN_UP) { // spin here means S^\dagger
 			// FIXME: Count over a (up)
@@ -198,7 +203,7 @@ public:
 	                             WordType ket2,
 	                             SizeType site,
 	                             SizeType spin,
-	                             SizeType orb) const
+	                             SizeType orb) const override
 	{
 		return (spin == SPIN_UP) ? basis1_.isThereAnElectronAt(ket1, site, orb)
 		                         : basis1_.isThereAnElectronAt(ket2, site, orb);
@@ -225,11 +230,14 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	SizeType orbsPerSite(SizeType) const { throw PsimagLite::RuntimeError("orbsPerSite\n"); }
+	SizeType orbsPerSite(SizeType) const override
+	{
+		throw PsimagLite::RuntimeError("orbsPerSite\n");
+	}
 
-	SizeType orbs() const { throw PsimagLite::RuntimeError("orbs\n"); }
+	SizeType orbs() const override { throw PsimagLite::RuntimeError("orbs\n"); }
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		bool     isBinary = (binaryOrDecimal == BaseType::PRINT_BINARY);
 		SizeType hilbert  = 1;
@@ -241,8 +249,8 @@ public:
 		}
 	}
 
-	virtual bool
-	getBra(WordType&, WordType, WordType, const LabeledOperator&, SizeType, SizeType) const
+	bool getBra(WordType&, WordType, WordType, const LabeledOperator&, SizeType, SizeType)
+	    const override
 	{
 		throw PsimagLite::RuntimeError("BasisFeAs: getBra\n");
 	}

--- a/LanczosPlusPlus/src/Models/FeBasedSc/FeBasedSc.h
+++ b/LanczosPlusPlus/src/Models/FeBasedSc/FeBasedSc.h
@@ -157,26 +157,29 @@ public:
 		checkSpinOrbit();
 	}
 
-	~FeBasedSc() { BaseType::deleteGarbage(garbage_); }
+	~FeBasedSc() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return mp_.orbitals; }
+	SizeType orbitals(SizeType) const override { return mp_.orbitals; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	bool hasNewParts(std::pair<SizeType, SizeType>&       newParts,
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperator&               lOperator,
 	                 SizeType                             spin,
-	                 SizeType                             orb) const
+	                 SizeType                             orb) const override
 	{
 		return basis_.hasNewParts(newParts, oldParts, lOperator, spin, orb);
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		// Calculate diagonal elements AND count non-zero matrix elements
 		SizeType                                    hilbert = basis.size();
@@ -249,13 +252,14 @@ public:
 		matrix.setRow(hilbert, nCounter);
 	}
 
-	void matrixVectorProduct(VectorType& x, const VectorType& y) const
+	void matrixVectorProduct(VectorType& x, const VectorType& y) const override
 	{
 		matrixVectorProduct(x, y, basis_);
 	}
 
-	void
-	matrixVectorProduct(VectorType& x, const VectorType& y, const BasisBaseType& basis) const
+	void matrixVectorProduct(VectorType&          x,
+	                         const VectorType&    y,
+	                         const BasisBaseType& basis) const override
 	{
 		// Calculate off-diagonal elements AND store matrix
 		typedef MatrixVectorHelper                   HelperType;
@@ -270,18 +274,18 @@ public:
 		threadObject.loopCreate(helper);
 	}
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType nup, SizeType ndown) const
+	BasisType* createBasis(SizeType nup, SizeType ndown) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, nup, ndown, mp_.orbitals);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
 private:
 

--- a/LanczosPlusPlus/src/Models/FermionSpinless/BasisFermionSpinless.hh
+++ b/LanczosPlusPlus/src/Models/FermionSpinless/BasisFermionSpinless.hh
@@ -24,47 +24,53 @@ public:
 	    , basis_(geometry.numberOfSites(), ne)
 	{ }
 
-	PairIntType parts() const { return PairIntType(ne_, 0); }
+	PairIntType parts() const override { return PairIntType(ne_, 0); }
 
 	static const WordType& bitmask(SizeType i) { return BasisType::bitmask(i); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType dofs() const { return 1; }
+	SizeType dofs() const override { return 1; }
 
-	virtual SizeType hilbertOneSite(SizeType) const { return 2; }
+	SizeType hilbertOneSite(SizeType) const override { return 2; }
 
-	SizeType perfectIndex(const VectorWordType& kets) const
+	SizeType perfectIndex(const VectorWordType& kets) const override
 	{
 		assert(kets.size() == 1);
 		return perfectIndex(kets[0], 0);
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType) const { return basis_.perfectIndex(ket1); }
+	SizeType perfectIndex(WordType ket1, WordType) const override
+	{
+		return basis_.perfectIndex(ket1);
+	}
 
-	virtual SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("perfectIndex\n");
 	}
 
-	WordType operator()(SizeType i, SizeType) const
+	WordType operator()(SizeType i, SizeType) const override
 	{
 		assert(i < basis_.size());
 		return basis_[i];
 	}
 
-	SizeType
-	isThereAnElectronAt(WordType ket, WordType, SizeType site, SizeType, SizeType) const
+	SizeType isThereAnElectronAt(WordType ket,
+	                             WordType,
+	                             SizeType site,
+	                             SizeType,
+	                             SizeType) const override
 	{
 		return basis_.isThereAnElectronAt(ket, site);
 	}
 
-	SizeType getN(WordType ket, WordType, SizeType site, SizeType, SizeType) const
+	SizeType getN(WordType ket, WordType, SizeType site, SizeType, SizeType) const override
 	{
 		return basis_.getN(ket, site);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType, SizeType) const
+	int doSignGf(WordType a, WordType b, SizeType ind, SizeType, SizeType) const override
 	{
 		if (ind == 0)
 			return 1;
@@ -81,14 +87,14 @@ public:
 		return s;
 	}
 
-	int
-	doSign(WordType ket1, WordType, SizeType i, SizeType, SizeType j, SizeType, SizeType) const
+	int doSign(WordType ket1, WordType, SizeType i, SizeType, SizeType j, SizeType, SizeType)
+	    const override
 	{
 		assert(i <= j);
 		return basis_.doSign(ket1, i, j);
 	}
 
-	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType) const
+	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("doSignSpSm\n");
 	}
@@ -98,7 +104,7 @@ public:
 	                        const LabeledOperatorType& lOperator,
 	                        SizeType                   site,
 	                        SizeType,
-	                        SizeType) const
+	                        SizeType) const override
 	{
 		WordType bra = 0;
 		bool     b   = getBra(bra, ket1, 0, lOperator, site, 0);
@@ -108,11 +114,11 @@ public:
 		return PairIntType(tmp, 1);
 	}
 
-	SizeType orbsPerSite(SizeType) const { return 1; }
+	SizeType orbsPerSite(SizeType) const override { return 1; }
 
-	SizeType orbs() const { return 1; }
+	SizeType orbs() const override { return 1; }
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		bool isBinary = (binaryOrDecimal == BaseType::PRINT_BINARY);
 		basis_.print(os, isBinary);
@@ -127,7 +133,7 @@ private:
 	            WordType,
 	            const LabeledOperatorType& lOperator,
 	            SizeType                   site,
-	            SizeType) const
+	            SizeType) const override
 	{
 		return basis_.getBra(bra, ket1, lOperator, site);
 	}

--- a/LanczosPlusPlus/src/Models/FermionSpinless/FermionSpinless.hh
+++ b/LanczosPlusPlus/src/Models/FermionSpinless/FermionSpinless.hh
@@ -54,16 +54,19 @@ public:
 		}
 	}
 
-	~FermionSpinless() { BaseType::deleteGarbage(garbage_); }
+	~FermionSpinless() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return 1; }
+	SizeType orbitals(SizeType) const override { return 1; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	//! Gf. related functions below:
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		SizeType                                    hilbert = basis.size();
 		typename PsimagLite::Vector<RealType>::Type diag(hilbert);
@@ -90,13 +93,14 @@ public:
 		matrix.setRow(hilbert, nCounter);
 	}
 
-	void matrixVectorProduct(VectorType& x, const VectorType& y) const
+	void matrixVectorProduct(VectorType& x, const VectorType& y) const override
 	{
 		matrixVectorProduct(x, y, basis_);
 	}
 
-	void
-	matrixVectorProduct(VectorType& x, VectorType const& y, const BasisBaseType& basis) const
+	void matrixVectorProduct(VectorType&          x,
+	                         VectorType const&    y,
+	                         const BasisBaseType& basis) const override
 	{
 		SizeType                                    hilbert = basis.size();
 		typename PsimagLite::Vector<RealType>::Type diag(hilbert);
@@ -129,7 +133,7 @@ public:
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperator&               lOperator,
 	                 SizeType,
-	                 SizeType) const
+	                 SizeType) const override
 	{
 		if (lOperator.id() == LabeledOperator::Label::OPERATOR_C
 		    || lOperator.id() == LabeledOperator::Label::OPERATOR_CDAGGER)
@@ -142,22 +146,22 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType ne, SizeType) const
+	BasisType* createBasis(SizeType ne, SizeType) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, ne);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
-	void printOperators(std::ostream& os) const
+	void printOperators(std::ostream& os) const override
 	{
 		SizeType ne = basis_.electrons();
 		os << "#Electrons= " << ne << "\n";

--- a/LanczosPlusPlus/src/Models/Heisenberg/BasisHeisenberg.h
+++ b/LanczosPlusPlus/src/Models/Heisenberg/BasisHeisenberg.h
@@ -45,22 +45,22 @@ public:
 		}
 	}
 
-	PairIntType parts() const { return PairIntType(twiceS_, szPlusConst_); }
+	PairIntType parts() const override { return PairIntType(twiceS_, szPlusConst_); }
 
 	static const WordType& bitmask(SizeType i) { return LanczosGlobals::bitmask(i); }
 
-	SizeType size() const { return data_.size(); }
+	SizeType size() const override { return data_.size(); }
 
-	SizeType dofs() const { return twiceS_ + 1; }
+	SizeType dofs() const override { return twiceS_ + 1; }
 
-	virtual SizeType hilbertOneSite(SizeType) const { return 1 + twiceS_; }
+	SizeType hilbertOneSite(SizeType) const override { return 1 + twiceS_; }
 
-	SizeType perfectIndex(const VectorWordType&) const
+	SizeType perfectIndex(const VectorWordType&) const override
 	{
 		throw PsimagLite::RuntimeError("BasisHeisenberg::perfectIndex kets\n");
 	}
 
-	SizeType perfectIndex(WordType ket, WordType) const
+	SizeType perfectIndex(WordType ket, WordType) const override
 	{
 		for (SizeType i = 0; i < data_.size(); ++i) {
 			if (ket == data_[i])
@@ -70,26 +70,28 @@ public:
 		throw PsimagLite::RuntimeError("perfectIndex: no index found\n");
 	}
 
-	WordType operator()(SizeType i, SizeType) const { return data_[i]; }
+	WordType operator()(SizeType i, SizeType) const override { return data_[i]; }
 
-	SizeType isThereAnElectronAt(WordType, WordType, SizeType, SizeType, SizeType) const
+	SizeType
+	isThereAnElectronAt(WordType, WordType, SizeType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisHeisenberg::isThereAnElectronAt\n");
 	}
 
-	SizeType getN(WordType ket1, WordType, SizeType site, SizeType, SizeType) const
+	SizeType getN(WordType ket1, WordType, SizeType site, SizeType, SizeType) const override
 	{
 		WordType mask = getMask();
 		ket1 >>= (bits_ * site);
 		return (ket1 & mask);
 	}
 
-	int doSignGf(WordType, WordType, SizeType, SizeType, SizeType) const
+	int doSignGf(WordType, WordType, SizeType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisHeisenberg::doSignGf\n");
 	}
 
-	int doSign(WordType, WordType, SizeType, SizeType, SizeType, SizeType, SizeType) const
+	int
+	doSign(WordType, WordType, SizeType, SizeType, SizeType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisHeisenberg::doSign\n");
 	}
@@ -99,7 +101,7 @@ public:
 	                        const LabeledOperatorType& lOperator,
 	                        SizeType                   site,
 	                        SizeType                   spin,
-	                        SizeType                   orb) const
+	                        SizeType                   orb) const override
 	{
 		if (twiceS_ != 1)
 			throw PsimagLite::RuntimeError("BasisHeisenberg::getBraIndex_ \n");
@@ -112,16 +114,16 @@ public:
 		return getBraIndex_(ket1, ket2, lOperator, site, spin, orb);
 	}
 
-	SizeType orbsPerSite(SizeType) const { return 1; }
+	SizeType orbsPerSite(SizeType) const override { return 1; }
 
-	SizeType orbs() const { return 1; }
+	SizeType orbs() const override { return 1; }
 
-	SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisHeisenberg::perfectIndex\n");
 	}
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		SizeType hilbert = 1;
 		hilbert <<= geometry_.numberOfSites();
@@ -145,7 +147,7 @@ private:
 	            WordType                   site1,
 	            const LabeledOperatorType& val1,
 	            SizeType                   site2,
-	            SizeType                   val2) const
+	            SizeType                   val2) const override
 	{
 		bra            = ket;
 		WordType mask1 = getMask();

--- a/LanczosPlusPlus/src/Models/Heisenberg/Heisenberg.h
+++ b/LanczosPlusPlus/src/Models/Heisenberg/Heisenberg.h
@@ -61,16 +61,19 @@ public:
 		}
 	}
 
-	~Heisenberg() { BaseType::deleteGarbage(garbage_); }
+	~Heisenberg() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return 1; }
+	SizeType orbitals(SizeType) const override { return 1; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	//! Gf. related functions below:
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		SizeType                                    hilbert = basis.size();
 		typename PsimagLite::Vector<RealType>::Type diag(hilbert, 0.0);
@@ -110,7 +113,7 @@ public:
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperatorType&           lOperator,
 	                 SizeType                             spin,
-	                 SizeType                             orb) const
+	                 SizeType                             orb) const override
 	{
 		if (lOperator.id() == LabeledOperatorType::Label::OPERATOR_SZ)
 			return false;
@@ -126,24 +129,24 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
 	void printBasis(std::ostream& os) const { os << basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType nup, SizeType ndown) const
+	BasisType* createBasis(SizeType nup, SizeType ndown) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, nup, ndown);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
-	void printOperators(std::ostream& os) const
+	void printOperators(std::ostream& os) const override
 	{
 		SizeType sites = geometry_.numberOfSites();
 		SizeType nup   = basis_.szPlusConst();

--- a/LanczosPlusPlus/src/Models/HubbardOneOrbital/BasisHubbardLanczos.h
+++ b/LanczosPlusPlus/src/Models/HubbardOneOrbital/BasisHubbardLanczos.h
@@ -32,29 +32,29 @@ public:
 	    , basis2_(geometry.numberOfSites(), ndown)
 	{ }
 
-	PairIntType parts() const { return PairIntType(nup_, ndown_); }
+	PairIntType parts() const override { return PairIntType(nup_, ndown_); }
 
 	static const WordType& bitmask(SizeType i) { return BasisType::bitmask(i); }
 
-	SizeType size() const { return basis1_.size() * basis2_.size(); }
+	SizeType size() const override { return basis1_.size() * basis2_.size(); }
 
 	//! Spin up and spin down
-	SizeType dofs() const { return 2; }
+	SizeType dofs() const override { return 2; }
 
-	virtual SizeType hilbertOneSite(SizeType) const { return 4; }
+	SizeType hilbertOneSite(SizeType) const override { return 4; }
 
-	SizeType perfectIndex(const VectorWordType& kets) const
+	SizeType perfectIndex(const VectorWordType& kets) const override
 	{
 		assert(kets.size() == 2);
 		return perfectIndex(kets[0], kets[1]);
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType ket2) const
+	SizeType perfectIndex(WordType ket1, WordType ket2) const override
 	{
 		return basis1_.perfectIndex(ket1) + basis2_.perfectIndex(ket2) * basis1_.size();
 	}
 
-	virtual SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("perfectIndex\n");
 	}
@@ -64,7 +64,7 @@ public:
 		return (what == SPIN_UP) ? basis1_.electrons() : basis2_.electrons();
 	}
 
-	WordType operator()(SizeType i, SizeType spin) const
+	WordType operator()(SizeType i, SizeType spin) const override
 	{
 		SizeType y = i / basis1_.size();
 		SizeType x = i % basis1_.size();
@@ -77,19 +77,20 @@ public:
 	                             WordType ket2,
 	                             SizeType site,
 	                             SizeType spin,
-	                             SizeType) const
+	                             SizeType) const override
 	{
 		if (spin == SPIN_UP)
 			return basis1_.isThereAnElectronAt(ket1, site);
 		return basis2_.isThereAnElectronAt(ket2, site);
 	}
 
-	SizeType getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType) const
+	SizeType
+	getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType) const override
 	{
 		return (spin == SPIN_UP) ? basis1_.getN(ket1, site) : basis2_.getN(ket2, site);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType sector, SizeType) const
+	int doSignGf(WordType a, WordType b, SizeType ind, SizeType sector, SizeType) const override
 	{
 		if (sector == SPIN_UP) {
 			if (ind == 0)
@@ -131,13 +132,13 @@ public:
 	           SizeType,
 	           SizeType j,
 	           SizeType,
-	           SizeType spin) const
+	           SizeType spin) const override
 	{
 		assert(i <= j);
 		return (spin == SPIN_UP) ? basis1_.doSign(ket1, i, j) : basis2_.doSign(ket2, i, j);
 	}
 
-	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType) const
+	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType) const override
 	{
 		if (spin == SPIN_UP) { // spin here means S^\dagger
 			// FIXME: Count over a (up)
@@ -153,7 +154,7 @@ public:
 	                        const LabeledOperatorType& lOperator,
 	                        SizeType                   site,
 	                        SizeType                   spin,
-	                        SizeType) const
+	                        SizeType) const override
 	{
 		if (lOperator.id() == LabeledOperatorType::Label::OPERATOR_SPLUS
 		    || lOperator.id() == LabeledOperatorType::Label::OPERATOR_SMINUS)
@@ -170,11 +171,11 @@ public:
 		return PairIntType(tmp, 1);
 	}
 
-	SizeType orbsPerSite(SizeType) const { return 1; }
+	SizeType orbsPerSite(SizeType) const override { return 1; }
 
-	SizeType orbs() const { return 1; }
+	SizeType orbs() const override { return 1; }
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		bool isBinary = (binaryOrDecimal == BaseType::PRINT_BINARY);
 		os << "\tUp sector\n";
@@ -190,7 +191,7 @@ private:
 	            WordType                   ket2,
 	            const LabeledOperatorType& lOperator,
 	            SizeType                   site,
-	            SizeType                   spin) const
+	            SizeType                   spin) const override
 	{
 		return (spin == SPIN_UP) ? basis1_.getBra(bra, ket1, lOperator, site)
 		                         : basis2_.getBra(bra, ket2, lOperator, site);

--- a/LanczosPlusPlus/src/Models/HubbardOneOrbital/BasisRashbaSOC.h
+++ b/LanczosPlusPlus/src/Models/HubbardOneOrbital/BasisRashbaSOC.h
@@ -53,26 +53,27 @@ public:
 		assert(k == hilbert);
 	}
 
-	PairIntType parts() const
+	PairIntType parts() const override
 	{
 		return PairIntType(0, 0); // dummy, we don't care
 	}
 
 	static const WordType& bitmask(SizeType i) { return BasisType::bitmask(i); }
 
-	SizeType size() const { return data_.size(); }
+	SizeType size() const override { return data_.size(); }
 
 	//! Spin up and spin down
-	SizeType dofs() const { throw PsimagLite::RuntimeError("dofs() unimplemented\n"); }
+	SizeType dofs() const override { throw PsimagLite::RuntimeError("dofs() unimplemented\n"); }
 
-	SizeType hilbertOneSite(SizeType) const { return 4; }
+	SizeType hilbertOneSite(SizeType) const override { return 4; }
 
-	SizeType perfectIndex(const typename PsimagLite::Vector<WordType>::Type& kets) const
+	SizeType
+	perfectIndex(const typename PsimagLite::Vector<WordType>::Type& kets) const override
 	{
 		throw PsimagLite::RuntimeError("dofs() perfectIndex\n");
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType ket2) const
+	SizeType perfectIndex(WordType ket1, WordType ket2) const override
 	{
 		const PairWordType p(ket1, ket2);
 		auto               it = std::find(data_.begin(), data_.end(), p);
@@ -81,12 +82,12 @@ public:
 		throw PsimagLite::RuntimeError("perfectIndex(): Index not found for state\n");
 	}
 
-	SizeType perfectIndex(WordType newKet, SizeType ispace, SizeType spinOfNew) const
+	SizeType perfectIndex(WordType newKet, SizeType ispace, SizeType spinOfNew) const override
 	{
 		throw PsimagLite::RuntimeError("dofs() perfectIndex\n");
 	}
 
-	WordType operator()(SizeType i, SizeType spin) const
+	WordType operator()(SizeType i, SizeType spin) const override
 	{
 		assert(i < data_.size());
 		return (spin == LanczosGlobals::SPIN_UP) ? data_[i].first : data_[i].second;
@@ -97,7 +98,7 @@ public:
 	                        const LabeledOperatorType&,
 	                        SizeType site,
 	                        SizeType spin,
-	                        SizeType orb) const
+	                        SizeType orb) const override
 	{
 		throw PsimagLite::RuntimeError("getBraIndex()\n");
 	}
@@ -108,19 +109,21 @@ public:
 	           SizeType orb1,
 	           SizeType j,
 	           SizeType orb2,
-	           SizeType spin) const
+	           SizeType spin) const override
 	{
 		assert(i <= j);
 		return (spin == SPIN_UP) ? BasisOneSpin::doSign(ket1, i, j)
 		                         : BasisOneSpin::doSign(ket2, i, j);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		throw PsimagLite::RuntimeError("doSignGf()\n");
 	}
 
-	int doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignSpSm(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		return 1;
 	}
@@ -129,30 +132,31 @@ public:
 	                             WordType ket2,
 	                             SizeType site,
 	                             SizeType spin,
-	                             SizeType) const
+	                             SizeType) const override
 	{
 		return (spin == LanczosGlobals::SPIN_UP)
 		    ? BasisOneSpin::isThereAnElectronAt(ket1, site)
 		    : BasisOneSpin::isThereAnElectronAt(ket2, site);
 	}
 
-	SizeType orbsPerSite(SizeType i) const { return 1; }
+	SizeType orbsPerSite(SizeType i) const override { return 1; }
 
-	SizeType orbs() const { return 1; }
+	SizeType orbs() const override { return 1; }
 
-	SizeType getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType) const
+	SizeType
+	getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType) const override
 	{
 		return (spin == LanczosGlobals::SPIN_UP) ? BasisOneSpin::getN(ket1, site)
 		                                         : BasisOneSpin::getN(ket2, site);
 	}
 
-	bool
-	getBra(WordType&, WordType, WordType, const LabeledOperatorType&, SizeType, SizeType) const
+	bool getBra(WordType&, WordType, WordType, const LabeledOperatorType&, SizeType, SizeType)
+	    const override
 	{
 		throw PsimagLite::RuntimeError("getBra()\n");
 	}
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		const SizeType n = data_.size();
 		for (SizeType i = 0; i < n; ++i)

--- a/LanczosPlusPlus/src/Models/HubbardOneOrbital/HubbardOneOrbital.h
+++ b/LanczosPlusPlus/src/Models/HubbardOneOrbital/HubbardOneOrbital.h
@@ -49,27 +49,31 @@ public:
 	    , helper_(geometry, mp_)
 	{ }
 
-	~HubbardOneOrbital() { BaseType::deleteGarbage(garbage_); }
+	~HubbardOneOrbital() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return 1; }
+	SizeType orbitals(SizeType) const override { return 1; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	//! Gf. related functions below:
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		helper_.setupHamiltonian(matrix, basis);
 	}
 
-	void matrixVectorProduct(VectorType& x, const VectorType& y) const
+	void matrixVectorProduct(VectorType& x, const VectorType& y) const override
 	{
 		matrixVectorProduct(x, y, basis_);
 	}
 
-	void
-	matrixVectorProduct(VectorType& x, VectorType const& y, const BasisBaseType& basis) const
+	void matrixVectorProduct(VectorType&          x,
+	                         VectorType const&    y,
+	                         const BasisBaseType& basis) const override
 	{
 		helper_.matrixVectorProduct(x, y, basis);
 	}
@@ -78,7 +82,7 @@ public:
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperator&               lOperator,
 	                 SizeType                             spin,
-	                 SizeType) const
+	                 SizeType) const override
 	{
 		if (lOperator.id() == LabeledOperator::Label::OPERATOR_C
 		    || lOperator.id() == LabeledOperator::Label::OPERATOR_CDAGGER)
@@ -98,22 +102,22 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType nup, SizeType ndown) const
+	BasisType* createBasis(SizeType nup, SizeType ndown) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, nup, ndown);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
-	void printOperators(std::ostream& os) const
+	void printOperators(std::ostream& os) const override
 	{
 		SizeType nup   = basis_.electrons(SPIN_UP);
 		SizeType ndown = basis_.electrons(SPIN_DOWN);

--- a/LanczosPlusPlus/src/Models/HubbardOneOrbital/HubbardOneOrbitalRashbaSOC.h
+++ b/LanczosPlusPlus/src/Models/HubbardOneOrbital/HubbardOneOrbitalRashbaSOC.h
@@ -52,27 +52,31 @@ public:
 	    , helper_(geometry, mp_)
 	{ }
 
-	~HubbardOneOrbitalRashbaSOC() { BaseType::deleteGarbage(garbage_); }
+	~HubbardOneOrbitalRashbaSOC() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return 1; }
+	SizeType orbitals(SizeType) const override { return 1; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	//! Gf. related functions below:
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		return helper_.setupHamiltonian(matrix, basis);
 	}
 
-	void matrixVectorProduct(VectorType& x, VectorType const& y) const
+	void matrixVectorProduct(VectorType& x, VectorType const& y) const override
 	{
 		matrixVectorProduct(x, y, basis_);
 	}
 
-	void
-	matrixVectorProduct(VectorType& x, VectorType const& y, const BasisBaseType& basis) const
+	void matrixVectorProduct(VectorType&          x,
+	                         VectorType const&    y,
+	                         const BasisBaseType& basis) const override
 	{
 		helper_.matrixVectorProduct(x, y, basis);
 	}
@@ -81,27 +85,27 @@ public:
 	                 const std::pair<SizeType, SizeType>&,
 	                 const LabeledOperator&,
 	                 SizeType,
-	                 SizeType) const
+	                 SizeType) const override
 	{
 		return false;
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType nup, SizeType ndown) const
+	BasisType* createBasis(SizeType nup, SizeType ndown) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, nup + ndown);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
-	void printOperators(std::ostream& os) const
+	void printOperators(std::ostream& os) const override
 	{
 		os << "WARNING: printOperators unimplemented\n";
 	}

--- a/LanczosPlusPlus/src/Models/Immm/BasisImmm.h
+++ b/LanczosPlusPlus/src/Models/Immm/BasisImmm.h
@@ -69,32 +69,32 @@ public:
 	    , basis2_(orbsPerSite_, ndown)
 	{ }
 
-	PairIntType parts() const { return PairIntType(nup_, ndown_); }
+	PairIntType parts() const override { return PairIntType(nup_, ndown_); }
 
 	static const WordType& bitmask(SizeType i) { return BasisType::bitmask(i); }
 
-	SizeType dofs() const { throw std::runtime_error("Wrong way!\n"); }
+	SizeType dofs() const override { throw std::runtime_error("Wrong way!\n"); }
 
-	SizeType size() const { return basis1_.size() * basis2_.size(); }
+	SizeType size() const override { return basis1_.size() * basis2_.size(); }
 
-	virtual SizeType hilbertOneSite(SizeType) const
+	SizeType hilbertOneSite(SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("hilbertOneSite unimplemented for IMMM\n");
 	}
 
-	WordType operator()(SizeType i, SizeType spin) const
+	WordType operator()(SizeType i, SizeType spin) const override
 	{
 		SizeType y = i / basis1_.size();
 		SizeType x = i % basis1_.size();
 		return (spin == SPIN_UP) ? basis1_[x] : basis2_[y];
 	}
 
-	SizeType perfectIndex(const VectorWordType&) const
+	SizeType perfectIndex(const VectorWordType&) const override
 	{
 		throw std::runtime_error("Wrong way!\n");
 	}
 
-	SizeType perfectIndex(WordType newKet, SizeType ispace, SizeType spinOfNew) const
+	SizeType perfectIndex(WordType newKet, SizeType ispace, SizeType spinOfNew) const override
 	{
 		if (spinOfNew == SPIN_UP) {
 			SizeType oldIndex1 = ispace / basis1_.size();
@@ -104,7 +104,7 @@ public:
 		return oldIndex2 + basis2_.perfectIndex(newKet) * basis2_.size();
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType ket2) const
+	SizeType perfectIndex(WordType ket1, WordType ket2) const override
 	{
 		return basis1_.perfectIndex(ket1) + basis2_.perfectIndex(ket2) * basis1_.size();
 	}
@@ -116,8 +116,11 @@ public:
 		return (spin == SPIN_UP) ? basis1_.getN(x, orb) : basis2_.getN(y, orb);
 	}
 
-	SizeType
-	getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType orb) const
+	SizeType getN(WordType ket1,
+	              WordType ket2,
+	              SizeType site,
+	              SizeType spin,
+	              SizeType orb) const override
 	{
 		return (spin == SPIN_UP) ? basis1_.getN(ket1, site, orb)
 		                         : basis2_.getN(ket2, site, orb);
@@ -128,7 +131,7 @@ public:
 	                        const LabeledOperator& lOperator,
 	                        SizeType               site,
 	                        SizeType               spin,
-	                        SizeType               orb) const
+	                        SizeType               orb) const override
 	{
 		WordType bra = 0;
 		bool     b   = getBra(bra, ket1, ket2, lOperator, site, spin, orb);
@@ -160,7 +163,7 @@ public:
 	           SizeType orb1,
 	           SizeType j,
 	           SizeType orb2,
-	           SizeType spin) const
+	           SizeType spin) const override
 	{
 		if (i > j) {
 			std::cerr << "FATAL: At doSign\n";
@@ -174,7 +177,8 @@ public:
 		return basis2_.doSign(ket2, i, orb1, j, orb2);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const
+	int
+	doSignGf(WordType a, WordType b, SizeType ind, SizeType spin, SizeType orb) const override
 	{
 		if (spin == SPIN_UP) {
 			return basis1_.doSignGf(a, ind, orb);
@@ -187,16 +191,16 @@ public:
 	                             WordType ket2,
 	                             SizeType site,
 	                             SizeType spin,
-	                             SizeType orb) const
+	                             SizeType orb) const override
 	{
 		if (spin == SPIN_UP)
 			return basis1_.isThereAnElectronAt(ket1, site, orb);
 		return basis2_.isThereAnElectronAt(ket2, site, orb);
 	}
 
-	SizeType orbsPerSite(SizeType i) const { return orbsPerSite_[i]; }
+	SizeType orbsPerSite(SizeType i) const override { return orbsPerSite_[i]; }
 
-	SizeType orbs() const { return orbsPerSite_[0]; }
+	SizeType orbs() const override { return orbsPerSite_[0]; }
 
 	SizeType electrons(SizeType what) const
 	{
@@ -220,7 +224,7 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		bool isBinary = (binaryOrDecimal == BaseType::PRINT_BINARY);
 		os << "\tUp sector\n";
@@ -229,8 +233,8 @@ public:
 		basis2_.print(os, isBinary);
 	}
 
-	virtual bool
-	getBra(WordType&, WordType, WordType, const LabeledOperator&, SizeType, SizeType) const
+	bool getBra(WordType&, WordType, WordType, const LabeledOperator&, SizeType, SizeType)
+	    const override
 	{
 		throw PsimagLite::RuntimeError("BasisImmm: getBra\n");
 	}

--- a/LanczosPlusPlus/src/Models/Immm/Immm.h
+++ b/LanczosPlusPlus/src/Models/Immm/Immm.h
@@ -59,13 +59,13 @@ public:
 	    , basis_(geometry, nup, ndown)
 	{ }
 
-	~Immm() { BaseType::deleteGarbage(garbage_); }
+	~Immm() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType site) const { return basis_.orbsPerSite(site); }
+	SizeType orbitals(SizeType site) const override { return basis_.orbsPerSite(site); }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const
+	void setupHamiltonian(SparseMatrixType& matrix) const override
 	{
 		if (!mp_.useReflectionSymmetry) {
 			setupHamiltonian(matrix, basis_);
@@ -77,18 +77,19 @@ public:
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperator&               lOperator,
 	                 SizeType                             spin,
-	                 SizeType                             orb) const
+	                 SizeType                             orb) const override
 	{
 		return basis_.hasNewParts(newParts, oldParts, lOperator, spin, orb);
 	}
 
-	void matrixVectorProduct(VectorType& x, const VectorType& y) const
+	void matrixVectorProduct(VectorType& x, const VectorType& y) const override
 	{
 		matrixVectorProduct(x, y, basis_);
 	}
 
-	void
-	matrixVectorProduct(VectorType& x, const VectorType& y, const BasisBaseType& basis) const
+	void matrixVectorProduct(VectorType&          x,
+	                         const VectorType&    y,
+	                         const BasisBaseType& basis) const override
 	{
 		// Calculate diagonal elements AND count non-zero matrix elements
 		SizeType                                    hilbert = basis.size();
@@ -118,11 +119,11 @@ public:
 		}
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		// Calculate diagonal elements AND count non-zero matrix elements
 		SizeType                                    hilbert = basis.size();
@@ -154,16 +155,16 @@ public:
 		matrix.setRow(hilbert, nCounter);
 	}
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisBaseType* createBasis(SizeType nup, SizeType ndown) const
+	BasisBaseType* createBasis(SizeType nup, SizeType ndown) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, nup, ndown);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
 private:
 

--- a/LanczosPlusPlus/src/Models/Kitaev/BasisKitaev.h
+++ b/LanczosPlusPlus/src/Models/Kitaev/BasisKitaev.h
@@ -32,26 +32,29 @@ public:
 		LanczosGlobals::doBitmask(sites);
 	}
 
-	PairIntType parts() const { throw PsimagLite::RuntimeError("BasisKitaev::parts()\n"); }
+	PairIntType parts() const override
+	{
+		throw PsimagLite::RuntimeError("BasisKitaev::parts()\n");
+	}
 
 	static const WordType& bitmask(SizeType i) { return LanczosGlobals::bitmask(i); }
 
-	SizeType size() const { return hilbert_; }
+	SizeType size() const override { return hilbert_; }
 
-	SizeType dofs() const
+	SizeType dofs() const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::dofs() please check\n");
 		return TWICE_THE_SPIN + 1;
 	}
 
-	SizeType hilbertOneSite(SizeType) const { return TWICE_THE_SPIN + 1; }
+	SizeType hilbertOneSite(SizeType) const override { return TWICE_THE_SPIN + 1; }
 
-	SizeType perfectIndex(const VectorWordType&) const
+	SizeType perfectIndex(const VectorWordType&) const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::perfectIndex kets\n");
 	}
 
-	SizeType perfectIndex(WordType ket, WordType) const
+	SizeType perfectIndex(WordType ket, WordType) const override
 	{
 		if (ket < hilbert_)
 			return ket;
@@ -59,31 +62,33 @@ public:
 		throw PsimagLite::RuntimeError("perfectIndex: no index found\n");
 	}
 
-	SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::perfectIndex\n");
 	}
 
-	WordType operator()(SizeType i, SizeType) const { return i; }
+	WordType operator()(SizeType i, SizeType) const override { return i; }
 
-	SizeType isThereAnElectronAt(WordType, WordType, SizeType, SizeType, SizeType) const
+	SizeType
+	isThereAnElectronAt(WordType, WordType, SizeType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::isThereAnElectronAt\n");
 	}
 
-	SizeType getN(WordType ket1, WordType, SizeType site, SizeType, SizeType) const
+	SizeType getN(WordType ket1, WordType, SizeType site, SizeType, SizeType) const override
 	{
 		WordType mask = getMask();
 		ket1 >>= (BITS * site);
 		return (ket1 & mask);
 	}
 
-	int doSignGf(WordType, WordType, SizeType, SizeType, SizeType) const
+	int doSignGf(WordType, WordType, SizeType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::doSignGf\n");
 	}
 
-	int doSign(WordType, WordType, SizeType, SizeType, SizeType, SizeType, SizeType) const
+	int
+	doSign(WordType, WordType, SizeType, SizeType, SizeType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::doSign\n");
 	}
@@ -93,7 +98,7 @@ public:
 	                        const LabeledOperatorType&,
 	                        SizeType site,
 	                        SizeType spin,
-	                        SizeType orb) const
+	                        SizeType orb) const override
 	{
 		throw PsimagLite::RuntimeError("BasisKitaev::getBraIndex() unimplemented yet\n");
 
@@ -109,11 +114,11 @@ public:
 		//		return getBraIndex_(ket1,ket2,operatorLabel,site,spin,orb);
 	}
 
-	SizeType orbsPerSite(SizeType) const { return 1; }
+	SizeType orbsPerSite(SizeType) const override { return 1; }
 
-	SizeType orbs() const { return 1; }
+	SizeType orbs() const override { return 1; }
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		SizeType hilbert = 1;
 		hilbert <<= geometry_.numberOfSites();
@@ -138,7 +143,7 @@ private:
 	            WordType                   site1,
 	            const LabeledOperatorType& val1,
 	            SizeType                   site2,
-	            SizeType                   val2) const
+	            SizeType                   val2) const override
 	{
 		bra            = ket;
 		WordType mask1 = getMask();

--- a/LanczosPlusPlus/src/Models/Kitaev/Kitaev.h
+++ b/LanczosPlusPlus/src/Models/Kitaev/Kitaev.h
@@ -70,16 +70,19 @@ public:
 		}
 	}
 
-	~Kitaev() { BaseType::deleteGarbage(garbage_); }
+	~Kitaev() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return 1; }
+	SizeType orbitals(SizeType) const override { return 1; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	//! Gf. related functions below:
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		SizeType       hilbert = basis.size();
 		VectorRealType diag(hilbert, 0.0);
@@ -124,7 +127,7 @@ public:
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperatorType&           lOperator,
 	                 SizeType                             spin,
-	                 SizeType                             orb) const
+	                 SizeType                             orb) const override
 	{
 		throw PsimagLite::RuntimeError("Kitaev::hasNewParts() unimplemented yet\n");
 		//		if (what==LanczosGlobals::OPERATOR_SZ)
@@ -141,24 +144,24 @@ public:
 		throw PsimagLite::RuntimeError(str.c_str());
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
 	void printBasis(std::ostream& os) const { os << basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType, SizeType) const
+	BasisType* createBasis(SizeType, SizeType) const override
 	{
 		BasisType* ptr = new BasisType(geometry_);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
-	void printOperators(std::ostream& os) const
+	void printOperators(std::ostream& os) const override
 	{
 		SizeType sites = geometry_.numberOfSites();
 		for (SizeType site = 0; site < sites; ++site)

--- a/LanczosPlusPlus/src/Models/TjMultiOrb/BasisTjMultiOrbLanczos.h
+++ b/LanczosPlusPlus/src/Models/TjMultiOrb/BasisTjMultiOrbLanczos.h
@@ -45,28 +45,28 @@ public:
 		std::sort(data_.begin(), data_.end());
 	}
 
-	PairIntType parts() const { return PairIntType(nup_, ndown_); }
+	PairIntType parts() const override { return PairIntType(nup_, ndown_); }
 
 	static const WordType& bitmask(SizeType i) { return LanczosGlobals::bitmask(i); }
 
-	SizeType size() const { return data_.size(); }
+	SizeType size() const override { return data_.size(); }
 
 	//! Spin up and spin down
-	SizeType dofs() const { return 2; }
+	SizeType dofs() const override { return 2; }
 
-	virtual SizeType hilbertOneSite(SizeType) const
+	SizeType hilbertOneSite(SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("hilbertOneSite unimplemented for t-J\n");
 	}
 
-	SizeType perfectIndex(const VectorWordType& kets) const
+	SizeType perfectIndex(const VectorWordType& kets) const override
 	{
 		assert(kets.size() == 2);
 		return (orbitals_ == 1) ? perfectIndex(kets[0], kets[1])
 		                        : bruteForce(kets[0], kets[1]);
 	}
 
-	SizeType perfectIndex(WordType ket1, WordType ket2) const
+	SizeType perfectIndex(WordType ket1, WordType ket2) const override
 	{
 		if (orbitals_ > 1)
 			return bruteForce(ket1, ket2);
@@ -128,7 +128,7 @@ public:
 
 	SizeType electrons(SizeType what) const { return (what == SPIN_UP) ? nup_ : ndown_; }
 
-	WordType operator()(SizeType i, SizeType spin) const
+	WordType operator()(SizeType i, SizeType spin) const override
 	{
 		SizeType n    = geometry_.numberOfSites() * orbitals_;
 		WordType w    = data_[i];
@@ -148,20 +148,23 @@ public:
 	                             WordType ket2,
 	                             SizeType site,
 	                             SizeType spin,
-	                             SizeType orb) const
+	                             SizeType orb) const override
 	{
 		return (spin == SPIN_UP) ? isThereAnElectronAt(ket1, site * orbitals_ + orb)
 		                         : isThereAnElectronAt(ket2, site * orbitals_ + orb);
 	}
 
-	SizeType
-	getN(WordType ket1, WordType ket2, SizeType site, SizeType spin, SizeType orb) const
+	SizeType getN(WordType ket1,
+	              WordType ket2,
+	              SizeType site,
+	              SizeType spin,
+	              SizeType orb) const override
 	{
 		return (spin == SPIN_UP) ? getN(ket1, site * orbitals_ + orb)
 		                         : getN(ket2, site * orbitals_ + orb);
 	}
 
-	int doSignGf(WordType a, WordType b, SizeType ind, SizeType sector, SizeType) const
+	int doSignGf(WordType a, WordType b, SizeType ind, SizeType sector, SizeType) const override
 	{
 		assert(orbitals_ == 1);
 		if (sector == SPIN_UP) {
@@ -202,7 +205,7 @@ public:
 	           SizeType orb,
 	           SizeType j,
 	           SizeType orb2,
-	           SizeType spin) const
+	           SizeType spin) const override
 	{
 		assert(i * orbitals_ + orb <= j * orbitals_ + orb2);
 		return (spin == SPIN_UP) ? doSign(ket1, i * orbitals_ + orb, j * orbitals_ + orb2)
@@ -214,7 +217,7 @@ public:
 	                        const LabeledOperatorType& lOperator,
 	                        SizeType                   site,
 	                        SizeType                   spin,
-	                        SizeType                   orb) const
+	                        SizeType                   orb) const override
 	{
 		LabeledOperatorType opC(LabeledOperatorType::Label::OPERATOR_C);
 
@@ -253,16 +256,16 @@ public:
 		return getBraIndex_(ket1, ket2, lOperator, site, spin, orb);
 	}
 
-	SizeType orbsPerSite(SizeType) const { return orbitals_; }
+	SizeType orbsPerSite(SizeType) const override { return orbitals_; }
 
-	SizeType orbs() const { return orbitals_; }
+	SizeType orbs() const override { return orbitals_; }
 
-	SizeType perfectIndex(WordType, SizeType, SizeType) const
+	SizeType perfectIndex(WordType, SizeType, SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("perfectIndex\n");
 	}
 
-	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const
+	void print(std::ostream& os, typename BaseType::PrintEnum binaryOrDecimal) const override
 	{
 		SizeType hilbert = 1;
 		hilbert <<= geometry_.numberOfSites();
@@ -278,7 +281,7 @@ public:
 	            WordType                   ket2,
 	            const LabeledOperatorType& lOperator,
 	            SizeType                   site,
-	            SizeType                   spin) const
+	            SizeType                   spin) const override
 	{
 		assert(orbitals_ == 1);
 		switch (lOperator.id()) {

--- a/LanczosPlusPlus/src/Models/TjMultiOrb/TjMultiOrb.h
+++ b/LanczosPlusPlus/src/Models/TjMultiOrb/TjMultiOrb.h
@@ -85,16 +85,19 @@ public:
 		}
 	}
 
-	~TjMultiOrb() { BaseType::deleteGarbage(garbage_); }
+	~TjMultiOrb() override { BaseType::deleteGarbage(garbage_); }
 
-	SizeType size() const { return basis_.size(); }
+	SizeType size() const override { return basis_.size(); }
 
-	SizeType orbitals(SizeType) const { return mp_.orbitals; }
+	SizeType orbitals(SizeType) const override { return mp_.orbitals; }
 
-	void setupHamiltonian(SparseMatrixType& matrix) const { setupHamiltonian(matrix, basis_); }
+	void setupHamiltonian(SparseMatrixType& matrix) const override
+	{
+		setupHamiltonian(matrix, basis_);
+	}
 
 	//! Gf. related functions below:
-	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const
+	void setupHamiltonian(SparseMatrixType& matrix, const BasisBaseType& basis) const override
 	{
 		SizeType                                    hilbert = basis.size();
 		typename PsimagLite::Vector<RealType>::Type diag(hilbert, 0.0);
@@ -137,7 +140,7 @@ public:
 	                 const std::pair<SizeType, SizeType>& oldParts,
 	                 const LabeledOperator&               lOperator,
 	                 SizeType                             spin,
-	                 SizeType) const
+	                 SizeType) const override
 	{
 		if (lOperator.id() == LabeledOperator::Label::OPERATOR_C
 		    || lOperator.id() == LabeledOperator::Label::OPERATOR_CDAGGER)
@@ -154,30 +157,31 @@ public:
 		throw std::runtime_error(str.c_str());
 	}
 
-	const GeometryType& geometry() const { return geometry_; }
+	const GeometryType& geometry() const override { return geometry_; }
 
-	const BasisType& basis() const { return basis_; }
+	const BasisType& basis() const override { return basis_; }
 
 	void printBasis(std::ostream& os) const { os << basis_; }
 
-	PsimagLite::String name() const { return __FILE__; }
+	PsimagLite::String name() const override { return __FILE__; }
 
-	BasisType* createBasis(SizeType nup, SizeType ndown) const
+	BasisType* createBasis(SizeType nup, SizeType ndown) const override
 	{
 		BasisType* ptr = new BasisType(geometry_, nup, ndown, mp_.orbitals);
 		garbage_.push_back(ptr);
 		return ptr;
 	}
 
-	virtual void matrixVectorProduct(VectorType&, const VectorType&, const BasisBaseType&) const
+	void
+	matrixVectorProduct(VectorType&, const VectorType&, const BasisBaseType&) const override
 	{
 		throw PsimagLite::RuntimeError(
 		    "ModelBase::matrixVectorProduct(3) not impl. for this model\n");
 	}
 
-	void print(std::ostream& os) const { os << mp_; }
+	void print(std::ostream& os) const override { os << mp_; }
 
-	void printOperators(std::ostream& os) const
+	void printOperators(std::ostream& os) const override
 	{
 		SizeType nup   = basis_.electrons(SPIN_UP);
 		SizeType ndown = basis_.electrons(SPIN_DOWN);

--- a/PsimagLite/src/PsimagLite/AST/AdditionalFunctions.h
+++ b/PsimagLite/src/PsimagLite/AST/AdditionalFunctions.h
@@ -27,13 +27,13 @@ template <typename VectorValueType> class Modulus : public Node<VectorValueType>
 
 public:
 
-	Modulus* clone() const { return new Modulus(*this); }
+	Modulus* clone() const override { return new Modulus(*this); }
 
-	virtual PsimagLite::String code() const { return "%"; }
+	PsimagLite::String code() const override { return "%"; }
 
-	virtual SizeType arity() const { return 2; }
+	SizeType arity() const override { return 2; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		using RealType = typename Real<ValueType>::Type;
 
@@ -57,13 +57,13 @@ template <typename VectorValueType> class Cosine : public Node<VectorValueType> 
 
 public:
 
-	Cosine* clone() const { return new Cosine(*this); }
+	Cosine* clone() const override { return new Cosine(*this); }
 
-	virtual PsimagLite::String code() const { return "cos"; }
+	PsimagLite::String code() const override { return "cos"; }
 
-	virtual SizeType arity() const { return 1; }
+	SizeType arity() const override { return 1; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 1);
 		return cos(v[0]);
@@ -76,13 +76,13 @@ template <typename VectorValueType> class Sine : public Node<VectorValueType> {
 
 public:
 
-	Sine* clone() const { return new Sine(*this); }
+	Sine* clone() const override { return new Sine(*this); }
 
-	virtual PsimagLite::String code() const { return "sin"; }
+	PsimagLite::String code() const override { return "sin"; }
 
-	virtual SizeType arity() const { return 1; }
+	SizeType arity() const override { return 1; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 1);
 		return sin(v[0]);
@@ -95,13 +95,13 @@ template <typename VectorValueType> class Exp : public Node<VectorValueType> {
 
 public:
 
-	Exp* clone() const { return new Exp(*this); }
+	Exp* clone() const override { return new Exp(*this); }
 
-	virtual PsimagLite::String code() const { return "exp"; }
+	PsimagLite::String code() const override { return "exp"; }
 
-	virtual SizeType arity() const { return 1; }
+	SizeType arity() const override { return 1; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 1);
 		return std::exp(v[0]);
@@ -114,13 +114,13 @@ template <typename VectorValueType> class TernaryOp : public Node<VectorValueTyp
 
 public:
 
-	TernaryOp* clone() const { return new TernaryOp(*this); }
+	TernaryOp* clone() const override { return new TernaryOp(*this); }
 
-	virtual PsimagLite::String code() const { return "?"; }
+	PsimagLite::String code() const override { return "?"; }
 
-	virtual SizeType arity() const { return 3; }
+	SizeType arity() const override { return 3; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 3);
 		SizeType b = static_cast<SizeType>(PsimagLite::norm(v[0]));
@@ -134,13 +134,13 @@ template <typename VectorValueType> class Log : public Node<VectorValueType> {
 
 public:
 
-	Log* clone() const { return new Log(*this); }
+	Log* clone() const override { return new Log(*this); }
 
-	virtual PsimagLite::String code() const { return "log"; }
+	PsimagLite::String code() const override { return "log"; }
 
-	virtual SizeType arity() const { return 1; }
+	SizeType arity() const override { return 1; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 1);
 		return log(v[0]);

--- a/PsimagLite/src/PsimagLite/AST/Node.h
+++ b/PsimagLite/src/PsimagLite/AST/Node.h
@@ -66,13 +66,13 @@ template <typename VectorValueType> class Plus : public Node<VectorValueType> {
 
 public:
 
-	Plus* clone() const { return new Plus(*this); }
+	Plus* clone() const override { return new Plus(*this); }
 
-	virtual PsimagLite::String code() const { return "+"; }
+	PsimagLite::String code() const override { return "+"; }
 
-	virtual SizeType arity() const { return 2; }
+	SizeType arity() const override { return 2; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 2);
 		return v[0] + v[1];
@@ -86,13 +86,13 @@ template <typename VectorValueType> class Minus : public Node<VectorValueType> {
 
 public:
 
-	Minus* clone() const { return new Minus(*this); }
+	Minus* clone() const override { return new Minus(*this); }
 
-	virtual PsimagLite::String code() const { return "-"; }
+	PsimagLite::String code() const override { return "-"; }
 
-	virtual SizeType arity() const { return 2; }
+	SizeType arity() const override { return 2; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 2);
 		return v[0] - v[1];
@@ -106,13 +106,13 @@ template <typename VectorValueType> class Times : public Node<VectorValueType> {
 
 public:
 
-	Times* clone() const { return new Times(*this); }
+	Times* clone() const override { return new Times(*this); }
 
-	virtual PsimagLite::String code() const { return "*"; }
+	PsimagLite::String code() const override { return "*"; }
 
-	virtual SizeType arity() const { return 2; }
+	SizeType arity() const override { return 2; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		if (v.size() != 2) {
 			throw RuntimeError("Expected two arguments for operator *, but found "
@@ -140,16 +140,16 @@ public:
 	    : kind_(kind)
 	{ }
 
-	DividedBy* clone() const { return new DividedBy(*this); }
+	DividedBy* clone() const override { return new DividedBy(*this); }
 
-	virtual PsimagLite::String code() const
+	PsimagLite::String code() const override
 	{
 		return (kind_ == Kind::FLOATING_POINT) ? "/" : "i/";
 	}
 
-	virtual SizeType arity() const { return 2; }
+	SizeType arity() const override { return 2; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 2);
 		if (std::norm(v[1]) < 1e-6)
@@ -232,21 +232,21 @@ public:
 		strOneChar_[0] = char_;
 	}
 
-	Input* clone() const { return new Input(*this); }
+	Input* clone() const override { return new Input(*this); }
 
-	virtual PsimagLite::String code() const { return strOneChar_; }
+	PsimagLite::String code() const override { return strOneChar_; }
 
-	virtual SizeType arity() const { return 0; }
+	SizeType arity() const override { return 0; }
 
-	virtual ValueType exec(const VectorValueType& v) const
+	ValueType exec(const VectorValueType& v) const override
 	{
 		assert(v.size() == 0);
 		return input_;
 	}
 
-	virtual void set(const ValueType& x) const { input_ = x; }
+	void set(const ValueType& x) const override { input_ = x; }
 
-	virtual bool isInput() const { return true; }
+	bool isInput() const override { return true; }
 
 private:
 

--- a/PsimagLite/src/PsimagLite/Geometry/Honeycomb.h
+++ b/PsimagLite/src/PsimagLite/Geometry/Honeycomb.h
@@ -117,37 +117,40 @@ public:
 		} catch (std::exception&) { }
 	}
 
-	virtual SizeType maxConnections() const
+	SizeType maxConnections() const override
 	{
 		// max connections broken when splitting the lattice
 		return ly_ + 1; // overestimate probably
 	}
 
-	virtual SizeType dirs() const { return 3; }
+	SizeType dirs() const override { return 3; }
 
-	virtual SizeType length(SizeType) const { return this->unimplemented("length"); }
+	SizeType length(SizeType) const override { return this->unimplemented("length"); }
 
-	virtual SizeType translate(SizeType, SizeType, SizeType) const
+	SizeType translate(SizeType, SizeType, SizeType) const override
 	{
 		return this->unimplemented("translate");
 	}
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		throw RuntimeError("Honeycomb::getVectorSize() unimplemented\n");
 	}
 
-	bool connected(SizeType i1, SizeType i2) const { return connectedInternal(i1, i2).first; }
+	bool connected(SizeType i1, SizeType i2) const override
+	{
+		return connectedInternal(i1, i2).first;
+	}
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType i1, SizeType i2) const
+	SizeType calcDir(SizeType i1, SizeType i2) const override
 	{
 		std::pair<bool, Dir> bdir = connectedInternal(i1, i2);
 		assert(bdir.first);
 		return bdir.second;
 	}
 
-	bool fringe(SizeType i, SizeType smax, SizeType emin) const
+	bool fringe(SizeType i, SizeType smax, SizeType emin) const override
 	{
 		if (i <= smax)
 			return isThereAneighbor(i, emin, linSize_);
@@ -159,20 +162,20 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType handle(SizeType i1, SizeType i2) const
+	SizeType handle(SizeType i1, SizeType i2) const override
 	{
 		throw RuntimeError("Honeycomb::handle() unimplemented\n");
 	}
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const override
 	{
 		throw RuntimeError("Honeycomb::getSubstituteSite() unimplemented\n");
 	}
 
-	String label() const { return "Honeycomb"; }
+	String label() const override { return "Honeycomb"; }
 
-	SizeType findReflection(SizeType) const
+	SizeType findReflection(SizeType) const override
 	{
 		throw RuntimeError("findReflection: unimplemented (sorry)\n");
 	}

--- a/PsimagLite/src/PsimagLite/Geometry/KTwoNiFFour.h
+++ b/PsimagLite/src/PsimagLite/Geometry/KTwoNiFFour.h
@@ -120,22 +120,22 @@ public:
 		std::cout << "KTwoNiFFour: SIGN CHANGE=" << signChange_ << "\n";
 	}
 
-	SizeType getVectorSize(SizeType) const
+	SizeType getVectorSize(SizeType) const override
 	{
 		assert(false);
 		throw RuntimeError("getVectorSize: unimplemented\n");
 	}
 
-	virtual SizeType dirs() const { return 4; }
+	SizeType dirs() const override { return 4; }
 
-	virtual SizeType length(SizeType) const { return this->unimplemented("length"); }
+	SizeType length(SizeType) const override { return this->unimplemented("length"); }
 
-	virtual SizeType translate(SizeType, SizeType, SizeType) const
+	SizeType translate(SizeType, SizeType, SizeType) const override
 	{
 		return this->unimplemented("translate");
 	}
 
-	bool connected(SizeType i1, SizeType i2) const
+	bool connected(SizeType i1, SizeType i2) const override
 	{
 		if (i1 == i2)
 			return false;
@@ -174,7 +174,7 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType i1, SizeType i2) const
+	SizeType calcDir(SizeType i1, SizeType i2) const override
 	{
 		PairType type1 = findTypeOfSite(i1);
 		PairType type2 = findTypeOfSite(i2);
@@ -203,7 +203,7 @@ public:
 		return (type1.second == SUBTYPE_X) ? DIR_X : DIR_Y;
 	}
 
-	bool fringe(SizeType i, SizeType smax, SizeType emin) const
+	bool fringe(SizeType i, SizeType smax, SizeType emin) const override
 	{
 		SizeType r = smax % 4;
 		switch (r) {
@@ -221,14 +221,14 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType handle(SizeType, SizeType) const
+	SizeType handle(SizeType, SizeType) const override
 	{
 		assert(false);
 		return 0;
 	}
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const override
 	{
 		SizeType r = smax % 4;
 		switch (r) {
@@ -245,16 +245,16 @@ public:
 		return 0;
 	}
 
-	String label() const { return "KTwoNiFFour"; }
+	String label() const override { return "KTwoNiFFour"; }
 
-	SizeType maxConnections() const { return 6; }
+	SizeType maxConnections() const override { return 6; }
 
-	SizeType findReflection(SizeType) const
+	SizeType findReflection(SizeType) const override
 	{
 		throw RuntimeError("findReflection: unimplemented (sorry)\n");
 	}
 
-	SizeType matrixRank(SizeType, SizeType) const
+	SizeType matrixRank(SizeType, SizeType) const override
 	{
 		SizeType sites = linSize_;
 		SizeType no    = 0;
@@ -270,7 +270,7 @@ public:
 	}
 
 	// FIXME: GENERALIZE by using orbitals per type of site
-	int index(SizeType i, SizeType orb, SizeType) const
+	int index(SizeType i, SizeType orb, SizeType) const override
 	{
 		SizeType type1 = findTypeOfSite(i).first;
 		if (type1 == TYPE_C && orb > 0)
@@ -283,7 +283,7 @@ public:
 		return sites + i - tmp;
 	}
 
-	int signChange(SizeType i1, SizeType i2) const
+	int signChange(SizeType i1, SizeType i2) const override
 	{
 		// change the sign of Cu-O
 		SizeType newi1 = std::min(i1, i2);
@@ -304,7 +304,7 @@ public:
 		return sign1;
 	}
 
-	SizeType orbitals(SizeType orbs, SizeType site) const
+	SizeType orbitals(SizeType orbs, SizeType site) const override
 	{
 		PairType type1 = findTypeOfSite(site);
 		return (type1.first == TYPE_C) ? 1 : orbs;

--- a/PsimagLite/src/PsimagLite/Geometry/Ladder.h
+++ b/PsimagLite/src/PsimagLite/Geometry/Ladder.h
@@ -134,11 +134,11 @@ public:
 			throw RuntimeError("Ladder: leg must divide number of sites\n");
 	}
 
-	virtual SizeType maxConnections() const { return (isPeriodicX_) ? linSize_ : leg_ + 1; }
+	SizeType maxConnections() const override { return (isPeriodicX_) ? linSize_ : leg_ + 1; }
 
-	virtual SizeType dirs() const { return 2; }
+	SizeType dirs() const override { return 2; }
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		if (dirId == DIRECTION_X)
 			return (isPeriodicX_) ? linSize_ : linSize_ - leg_;
@@ -148,7 +148,7 @@ public:
 		throw RuntimeError("Unknown direction\n");
 	}
 
-	bool connected(SizeType i1, SizeType i2) const
+	bool connected(SizeType i1, SizeType i2) const override
 	{
 		if (i1 == i2)
 			return false;
@@ -163,13 +163,13 @@ public:
 		return false;
 	}
 
-	SizeType calcDir(SizeType i1, SizeType i2) const
+	SizeType calcDir(SizeType i1, SizeType i2) const override
 	{
 		assert(connected(i1, i2));
 		return (sameColumn(i1, i2)) ? DIRECTION_Y : DIRECTION_X;
 	}
 
-	bool fringe(SizeType i, SizeType smax, SizeType emin) const
+	bool fringe(SizeType i, SizeType smax, SizeType emin) const override
 	{
 		SizeType c = smax % leg_;
 		SizeType r = 2 + 2 * c;
@@ -185,7 +185,7 @@ public:
 	}
 
 	// siteEnv is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteEnv) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteEnv) const override
 	{
 		if (smax + 1 == emin)
 			return siteEnv; // finite loops
@@ -198,7 +198,7 @@ public:
 		return siteEnv - s * leg_;
 	}
 
-	SizeType handle(SizeType i1, SizeType i2) const
+	SizeType handle(SizeType i1, SizeType i2) const override
 	{
 		const SizeType dir  = calcDir(i1, i2);
 		const SizeType imin = (i1 < i2) ? i1 : i2;
@@ -236,9 +236,9 @@ public:
 		return false;
 	}
 
-	String label() const { return "ladder"; }
+	String label() const override { return "ladder"; }
 
-	SizeType length(SizeType i) const
+	SizeType length(SizeType i) const override
 	{
 		assert(i < 2);
 		return (i == 1) ? leg_ : SizeType(linSize_ / leg_);
@@ -246,7 +246,7 @@ public:
 
 	SizeType leg() const { return leg_; }
 
-	SizeType translate(SizeType site, SizeType dir, SizeType amount) const
+	SizeType translate(SizeType site, SizeType dir, SizeType amount) const override
 	{
 		assert(dir < 2);
 		SizeType x  = SizeType(site / leg_);
@@ -261,7 +261,7 @@ public:
 		return ind;
 	}
 
-	SizeType findReflection(SizeType site) const
+	SizeType findReflection(SizeType site) const override
 	{
 		SizeType x   = SizeType(site / leg_);
 		SizeType y   = site % leg_;

--- a/PsimagLite/src/PsimagLite/Geometry/LadderBath.h
+++ b/PsimagLite/src/PsimagLite/Geometry/LadderBath.h
@@ -110,29 +110,29 @@ public:
 		ladder_ = new LadderType(clusterSize_, io);
 	}
 
-	~LadderBath()
+	~LadderBath() override
 	{
 		if (ladder_)
 			delete ladder_;
 	}
 
-	virtual SizeType dirs() const { return 3; }
+	SizeType dirs() const override { return 3; }
 
-	virtual SizeType length(SizeType) const { return this->unimplemented("length"); }
+	SizeType length(SizeType) const override { return this->unimplemented("length"); }
 
-	virtual SizeType translate(SizeType, SizeType, SizeType) const
+	SizeType translate(SizeType, SizeType, SizeType) const override
 	{
 		return this->unimplemented("translate");
 	}
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		if (dirId == DIRECTION_BATH)
 			return bathSitesPerSite_ * clusterSize_;
 		return ladder_->getVectorSize(dirId);
 	}
 
-	bool connected(SizeType i1, SizeType i2) const
+	bool connected(SizeType i1, SizeType i2) const override
 	{
 		if (i1 == i2)
 			return false;
@@ -154,7 +154,7 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType i1, SizeType i2) const
+	SizeType calcDir(SizeType i1, SizeType i2) const override
 	{
 		int c1 = getClusterSite(i1).first;
 		int c2 = getClusterSite(i2).first;
@@ -166,7 +166,7 @@ public:
 		return DIRECTION_BATH;
 	}
 
-	bool fringe(SizeType i, SizeType smax, SizeType emin) const
+	bool fringe(SizeType i, SizeType smax, SizeType emin) const override
 	{
 		int c = getClusterSite(i).first;
 		if (c >= 0)
@@ -175,7 +175,7 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType handle(SizeType i1, SizeType i2) const
+	SizeType handle(SizeType i1, SizeType i2) const override
 	{
 		PairType c1 = getClusterSite(i1);
 		PairType c2 = getClusterSite(i2);
@@ -194,7 +194,7 @@ public:
 	}
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew) const override
 	{
 		PairType c1 = getClusterSite(siteNew);
 
@@ -214,11 +214,11 @@ public:
 		throw RuntimeError(str);
 	}
 
-	String label() const { return "ladderbath"; }
+	String label() const override { return "ladderbath"; }
 
-	SizeType maxConnections() const { return clusterSize_ + 1; }
+	SizeType maxConnections() const override { return clusterSize_ + 1; }
 
-	SizeType findReflection(SizeType) const
+	SizeType findReflection(SizeType) const override
 	{
 		throw RuntimeError("findReflection: unimplemented (sorry)\n");
 	}

--- a/PsimagLite/src/PsimagLite/Geometry/LadderX.h
+++ b/PsimagLite/src/PsimagLite/Geometry/LadderX.h
@@ -106,18 +106,18 @@ public:
 	    , leg_(ladder_.leg())
 	{ }
 
-	virtual SizeType maxConnections() const { return leg_ + 1; }
+	SizeType maxConnections() const override { return leg_ + 1; }
 
-	virtual SizeType dirs() const { return 4; }
+	SizeType dirs() const override { return 4; }
 
-	virtual SizeType length(SizeType) const { return this->unimplemented("length"); }
+	SizeType length(SizeType) const override { return this->unimplemented("length"); }
 
-	virtual SizeType translate(SizeType, SizeType, SizeType) const
+	SizeType translate(SizeType, SizeType, SizeType) const override
 	{
 		return this->unimplemented("translate");
 	}
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		switch (dirId) {
 		case DIRECTION_XPY:
@@ -129,7 +129,7 @@ public:
 		return ladder_.getVectorSize(dirId);
 	}
 
-	bool connected(SizeType i1, SizeType i2) const
+	bool connected(SizeType i1, SizeType i2) const override
 	{
 		if (i1 == i2)
 			return false;
@@ -155,7 +155,7 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType i1, SizeType i2) const
+	SizeType calcDir(SizeType i1, SizeType i2) const override
 	{
 		if (ladder_.sameColumn(i1, i2))
 			return DIRECTION_Y;
@@ -167,7 +167,7 @@ public:
 		return DIRECTION_XMY;
 	}
 
-	bool fringe(SizeType i, SizeType smax, SizeType emin) const
+	bool fringe(SizeType i, SizeType smax, SizeType emin) const override
 	{
 		bool a = (i < emin && i >= smax - 1);
 		bool b = (i > smax && i <= emin + 1);
@@ -179,7 +179,7 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType handle(SizeType i1, SizeType i2) const
+	SizeType handle(SizeType i1, SizeType i2) const override
 	{
 		SizeType dir  = calcDir(i1, i2);
 		SizeType imin = (i1 < i2) ? i1 : i2;
@@ -197,14 +197,14 @@ public:
 	}
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const override
 	{
 		return smax + siteNew2 - emin + 1;
 	}
 
-	String label() const { return "ladderx"; }
+	String label() const override { return "ladderx"; }
 
-	SizeType findReflection(SizeType) const
+	SizeType findReflection(SizeType) const override
 	{
 		throw RuntimeError("findReflection: unimplemented (sorry)\n");
 	}

--- a/PsimagLite/src/PsimagLite/Geometry/LongChain.h
+++ b/PsimagLite/src/PsimagLite/Geometry/LongChain.h
@@ -120,20 +120,20 @@ public:
 			RuntimeError("LongChain::ctor()\n");
 	}
 
-	virtual SizeType maxConnections() const { return (isPeriodic_) ? linSize_ : 1; }
+	SizeType maxConnections() const override { return (isPeriodic_) ? linSize_ : 1; }
 
-	virtual SizeType dirs() const { return 1; }
+	SizeType dirs() const override { return 1; }
 
-	SizeType handle(SizeType i, SizeType j) const { return (i < j) ? i : j; }
+	SizeType handle(SizeType i, SizeType j) const override { return (i < j) ? i : j; }
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		assert(dirId == DIRECTION_X);
 		const SizeType oneOrZero = (isPeriodic_) ? 1 : 0;
 		return linSize_ - distance_ + oneOrZero;
 	}
 
-	bool connected(SizeType i1, SizeType i2) const
+	bool connected(SizeType i1, SizeType i2) const override
 	{
 		if (i1 == i2)
 			return false;
@@ -147,9 +147,9 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType, SizeType) const { return DIRECTION_X; }
+	SizeType calcDir(SizeType, SizeType) const override { return DIRECTION_X; }
 
-	bool fringe(SizeType i, SizeType smax, SizeType emin) const
+	bool fringe(SizeType i, SizeType smax, SizeType emin) const override
 	{
 		SizeType emin2 = smax + 1;
 		if (i <= smax) {
@@ -161,7 +161,7 @@ public:
 	}
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const override
 	{
 		assert(siteNew2 >= emin);
 		SizeType tmp = siteNew2 - emin + smax + 1;
@@ -169,17 +169,17 @@ public:
 		return tmp;
 	}
 
-	String label() const { return "longchain"; }
+	String label() const override { return "longchain"; }
 
-	SizeType findReflection(SizeType site) const { return linSize_ - site - 1; }
+	SizeType findReflection(SizeType site) const override { return linSize_ - site - 1; }
 
-	SizeType length(SizeType i) const
+	SizeType length(SizeType i) const override
 	{
 		assert(i == 0);
 		return linSize_;
 	}
 
-	SizeType translate(SizeType site, SizeType dir, SizeType amount) const
+	SizeType translate(SizeType site, SizeType dir, SizeType amount) const override
 	{
 		assert(dir == 0);
 

--- a/PsimagLite/src/PsimagLite/Geometry/LongRange.h
+++ b/PsimagLite/src/PsimagLite/Geometry/LongRange.h
@@ -144,37 +144,37 @@ public:
 		}
 	}
 
-	virtual void set(MatrixType& m, SizeType orbitals) const
+	void set(MatrixType& m, SizeType orbitals) const override
 	{
 		m = matrix_;
 		if (orbitals != dofs_)
 			throw RuntimeError("General geometry connectors: wrong size\n");
 	}
 
-	virtual SizeType maxConnections() const
+	SizeType maxConnections() const override
 	{
 		return (maxConnections_ == 0) ? linSize_ * linSize_ * 0.25 : maxConnections_;
 	}
 
-	virtual SizeType dirs() const { return 1; }
+	SizeType dirs() const override { return 1; }
 
-	SizeType handle(SizeType i, SizeType j) const { return (i < j) ? i : j; }
+	SizeType handle(SizeType i, SizeType j) const override { return (i < j) ? i : j; }
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		assert(dirId == 0);
 		throw RuntimeError("LongRange::getVectorSize(): unimplemented\n");
 	}
 
-	bool connected(SizeType i1, SizeType i2) const { return true; }
+	bool connected(SizeType i1, SizeType i2) const override { return true; }
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType, SizeType) const { return 0; }
+	SizeType calcDir(SizeType, SizeType) const override { return 0; }
 
-	bool fringe(SizeType, SizeType, SizeType) const { return true; }
+	bool fringe(SizeType, SizeType, SizeType) const override { return true; }
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const
+	SizeType getSubstituteSite(SizeType smax, SizeType emin, SizeType siteNew2) const override
 	{
 		assert(siteNew2 >= emin);
 		SizeType tmp = siteNew2 - emin + smax + 1;
@@ -182,17 +182,17 @@ public:
 		return tmp;
 	}
 
-	String label() const { return "LongRange"; }
+	String label() const override { return "LongRange"; }
 
-	SizeType findReflection(SizeType site) const { return linSize_ - site - 1; }
+	SizeType findReflection(SizeType site) const override { return linSize_ - site - 1; }
 
-	SizeType length(SizeType i) const
+	SizeType length(SizeType i) const override
 	{
 		assert(i == 0);
 		return linSize_;
 	}
 
-	SizeType translate(SizeType site, SizeType dir, SizeType amount) const
+	SizeType translate(SizeType site, SizeType dir, SizeType amount) const override
 	{
 		assert(dir == 0);
 

--- a/PsimagLite/src/PsimagLite/Geometry/Star.h
+++ b/PsimagLite/src/PsimagLite/Geometry/Star.h
@@ -99,11 +99,11 @@ public:
 	    : linSize_(linSize)
 	{ }
 
-	virtual SizeType maxConnections() const { return linSize_ - 1; }
+	SizeType maxConnections() const override { return linSize_ - 1; }
 
-	virtual SizeType dirs() const { return 1; }
+	SizeType dirs() const override { return 1; }
 
-	SizeType handle(SizeType i, SizeType j) const
+	SizeType handle(SizeType i, SizeType j) const override
 	{
 		assert(i == CENTER || j == CENTER);
 		SizeType k      = (i == CENTER) ? j : i;
@@ -112,14 +112,14 @@ public:
 		return k - offset;
 	}
 
-	SizeType getVectorSize(SizeType dirId) const
+	SizeType getVectorSize(SizeType dirId) const override
 	{
 		if (dirId != DIRECTION_S)
 			throw RuntimeError("Star must have direction 0\n");
 		return linSize_ - 1;
 	}
 
-	bool connected(SizeType i1, SizeType i2) const
+	bool connected(SizeType i1, SizeType i2) const override
 	{
 		if (i1 == i2)
 			return false;
@@ -127,24 +127,27 @@ public:
 	}
 
 	// assumes i1 and i2 are connected
-	SizeType calcDir(SizeType, SizeType) const { return DIRECTION_S; }
+	SizeType calcDir(SizeType, SizeType) const override { return DIRECTION_S; }
 
-	bool fringe(SizeType i, SizeType, SizeType emin) const { return (i == emin); }
+	bool fringe(SizeType i, SizeType, SizeType emin) const override { return (i == emin); }
 
 	// siteNew2 is fringe in the environment
-	SizeType getSubstituteSite(SizeType, SizeType, SizeType siteNew2) const { return siteNew2; }
+	SizeType getSubstituteSite(SizeType, SizeType, SizeType siteNew2) const override
+	{
+		return siteNew2;
+	}
 
-	String label() const { return "star"; }
+	String label() const override { return "star"; }
 
-	SizeType findReflection(SizeType) const { throw RuntimeError("findReflection\n"); }
+	SizeType findReflection(SizeType) const override { throw RuntimeError("findReflection\n"); }
 
-	SizeType length(SizeType i) const
+	SizeType length(SizeType i) const override
 	{
 		assert(i == 0);
 		return linSize_;
 	}
 
-	SizeType translate(SizeType, SizeType dir, SizeType) const
+	SizeType translate(SizeType, SizeType dir, SizeType) const override
 	{
 		assert(dir == 0);
 

--- a/PsimagLite/src/PsimagLite/LanczosSolver.h
+++ b/PsimagLite/src/PsimagLite/LanczosSolver.h
@@ -30,7 +30,7 @@ public:
 	void computeOneState(RealType&         energy,
 	                     VectorType&       z,
 	                     const VectorType& initialVector,
-	                     SizeType          excited)
+	                     SizeType          excited) override
 	{
 		Profiling profiling("LanczosSolver", std::cout);
 
@@ -68,7 +68,7 @@ public:
 	void computeAllStatesBelow(VectorRealType&   eigs,
 	                           VectorVectorType& z,
 	                           const VectorType& initialVector,
-	                           SizeType          excited)
+	                           SizeType          excited) override
 	{
 		TridiagonalMatrixType ab;
 		ls_.decomposition(initialVector, ab, excited);

--- a/cincuenta/src/ImpuritySolverExactDiag.h
+++ b/cincuenta/src/ImpuritySolverExactDiag.h
@@ -61,7 +61,7 @@ public:
 	    , freq_enum_(PsimagLite::FreqEnum::MATSUBARA)
 	{ }
 
-	~ImpuritySolverExactDiag()
+	~ImpuritySolverExactDiag() override
 	{
 		delete solverParams_;
 		solverParams_ = nullptr;

--- a/dmrg/Engine/DensityMatrixLocal.h
+++ b/dmrg/Engine/DensityMatrixLocal.h
@@ -196,9 +196,9 @@ public:
 		}
 	}
 
-	virtual const BlockDiagonalMatrixType& operator()() { return data_; }
+	const BlockDiagonalMatrixType& operator()() override { return data_; }
 
-	void diag(typename PsimagLite::Vector<RealType>::Type& eigs, char jobz)
+	void diag(typename PsimagLite::Vector<RealType>::Type& eigs, char jobz) override
 	{
 		DiagBlockDiagMatrix<BlockDiagonalMatrixType>::diagonalise(data_, eigs, jobz);
 	}

--- a/dmrg/Engine/DensityMatrixSvd.h
+++ b/dmrg/Engine/DensityMatrixSvd.h
@@ -512,9 +512,9 @@ public:
 		profiling.end(msg.str());
 	}
 
-	virtual const BlockDiagonalMatrixType& operator()() { return data_; }
+	const BlockDiagonalMatrixType& operator()() override { return data_; }
 
-	void diag(VectorRealType& eigs, char jobz)
+	void diag(VectorRealType& eigs, char jobz) override
 	{
 		PsimagLite::Profiling profiling("DensityMatrixSvdDiag", std::cout);
 
@@ -552,16 +552,16 @@ public:
 	}
 
 	// needed for WFT
-	const typename PsimagLite::Vector<MatrixType>::Type& vts() const
+	const typename PsimagLite::Vector<MatrixType>::Type& vts() const override
 	{
 		return persistentSvd_.vts();
 	}
 
 	// needed for WFT
-	const VectorVectorRealType& s() const { return persistentSvd_.s(); }
+	const VectorVectorRealType& s() const override { return persistentSvd_.s(); }
 
 	// needed for WFT
-	const VectorQnType& qns() const { return persistentSvd_.qns(); }
+	const VectorQnType& qns() const override { return persistentSvd_.qns(); }
 
 	friend std::ostream& operator<<(std::ostream& os, const DensityMatrixSvd& dm)
 	{

--- a/dmrg/Engine/TargetParamsCommon.h
+++ b/dmrg/Engine/TargetParamsCommon.h
@@ -192,9 +192,9 @@ public:
 		return 0;
 	}
 
-	virtual SizeType sites() const { return sites_.size(); }
+	SizeType sites() const override { return sites_.size(); }
 
-	virtual SizeType sites(SizeType i) const
+	SizeType sites(SizeType i) const override
 	{
 		assert(i < sites_.size());
 		return sites_[i];
@@ -211,7 +211,7 @@ public:
 		return it - sites_.begin();
 	}
 
-	virtual void setOperator(SizeType i, SizeType j, const OperatorType& op)
+	void setOperator(SizeType i, SizeType j, const OperatorType& op) override
 	{
 		assert(i < sites_.size());
 		sites_[i] = j;
@@ -219,27 +219,27 @@ public:
 		aOperators_[i] = op;
 	}
 
-	virtual const VectorSizeType& startingLoops() const { return startingLoops_; }
+	const VectorSizeType& startingLoops() const override { return startingLoops_; }
 
-	virtual typename BaseType::ConcatEnum concatenation() const { return concatenation_; }
+	typename BaseType::ConcatEnum concatenation() const override { return concatenation_; }
 
-	virtual const VectorOperatorType& aOperators() const { return aOperators_; }
+	const VectorOperatorType& aOperators() const override { return aOperators_; }
 
-	virtual bool noOperator() const { return noOperator_; }
+	bool noOperator() const override { return noOperator_; }
 
-	virtual void noOperator(bool x) { noOperator_ = x; }
+	void noOperator(bool x) override { noOperator_ = x; }
 
-	virtual bool skipTimeZero() const { return skipTimeZero_; }
+	bool skipTimeZero() const override { return skipTimeZero_; }
 
-	virtual bool isEnergyForExp() const { return isEnergyForExp_; }
+	bool isEnergyForExp() const override { return isEnergyForExp_; }
 
-	virtual RealType energyForExp() const { return energyForExp_; }
+	RealType energyForExp() const override { return energyForExp_; }
 
-	virtual RealType gsWeight() const { return gsWeight_; }
+	RealType gsWeight() const override { return gsWeight_; }
 
-	virtual SizeType sectorIndex() const { return sectorLevel_.first; }
+	SizeType sectorIndex() const override { return sectorLevel_.first; }
 
-	virtual SizeType levelIndex() const { return sectorLevel_.second; }
+	SizeType levelIndex() const override { return sectorLevel_.second; }
 
 	void write(PsimagLite::String label, PsimagLite::IoSerializer& ioSerializer) const
 	{

--- a/dmrg/Engine/TargetParamsCorrection.h
+++ b/dmrg/Engine/TargetParamsCorrection.h
@@ -104,16 +104,16 @@ public:
 		return 0;
 	}
 
-	virtual SizeType sites() const { return 0; }
+	SizeType sites() const override { return 0; }
 
-	virtual RealType correctionA() const { return correctionA_; }
+	RealType correctionA() const override { return correctionA_; }
 
-	virtual SizeType sectorIndex() const
+	SizeType sectorIndex() const override
 	{
 		throw PsimagLite::RuntimeError("sectorIndex called for gs\n");
 	}
 
-	virtual SizeType levelIndex() const
+	SizeType levelIndex() const override
 	{
 		throw PsimagLite::RuntimeError("levelIndex called for gs\n");
 	}

--- a/dmrg/Engine/TargetParamsCorrectionVector.h
+++ b/dmrg/Engine/TargetParamsCorrectionVector.h
@@ -175,32 +175,32 @@ public:
 			err("FirstRitz must be 0 for Matsubara\n");
 	}
 
-	virtual RealType correctionA() const { return correctionA_; }
+	RealType correctionA() const override { return correctionA_; }
 
-	virtual SizeType type() const { return type_; }
+	SizeType type() const override { return type_; }
 
-	virtual void type(SizeType x) { type_ = x; }
+	void type(SizeType x) override { type_ = x; }
 
-	virtual SizeType cgSteps() const { return cgSteps_; }
+	SizeType cgSteps() const override { return cgSteps_; }
 
-	virtual PairFreqType omega() const { return omega_; }
+	PairFreqType omega() const override { return omega_; }
 
-	virtual void omega(PsimagLite::FreqEnum freqEnum, RealType x)
+	void omega(PsimagLite::FreqEnum freqEnum, RealType x) override
 	{
 		omega_ = PairFreqType(freqEnum, x);
 	}
 
-	virtual RealType eta() const { return eta_; }
+	RealType eta() const override { return eta_; }
 
-	virtual RealType cgEps() const { return cgEps_; }
+	RealType cgEps() const override { return cgEps_; }
 
-	virtual typename BaseType::AlgorithmEnum algorithm() const { return algorithm_; }
+	typename BaseType::AlgorithmEnum algorithm() const override { return algorithm_; }
 
 	virtual SizeType firstRitz() const { return firstRitz_; }
 
 	virtual SizeType nForFraction() const { return nForFraction_; }
 
-	virtual SizeType advanceEach() const { return advanceEach_; }
+	SizeType advanceEach() const override { return advanceEach_; }
 
 private:
 

--- a/dmrg/Engine/TargetParamsDynamic.h
+++ b/dmrg/Engine/TargetParamsDynamic.h
@@ -109,7 +109,7 @@ public:
 		return 0;
 	}
 
-	virtual SizeType type() const { return type_; }
+	SizeType type() const override { return type_; }
 
 private:
 

--- a/dmrg/Engine/TargetParamsGroundState.h
+++ b/dmrg/Engine/TargetParamsGroundState.h
@@ -93,14 +93,14 @@ public:
 	    : BaseType(targeting)
 	{ }
 
-	virtual SizeType sites() const { return 0; }
+	SizeType sites() const override { return 0; }
 
-	virtual SizeType sectorIndex() const
+	SizeType sectorIndex() const override
 	{
 		throw PsimagLite::RuntimeError("sectorIndex called for gs\n");
 	}
 
-	virtual SizeType levelIndex() const
+	SizeType levelIndex() const override
 	{
 		throw PsimagLite::RuntimeError("levelIndex called for gs\n");
 	}

--- a/dmrg/Engine/TargetParamsTimeStep.h
+++ b/dmrg/Engine/TargetParamsTimeStep.h
@@ -105,7 +105,7 @@ public:
 		} catch (std::exception&) { }
 	}
 
-	virtual RealType maxTime() const { return maxTime_; }
+	RealType maxTime() const override { return maxTime_; }
 
 private:
 

--- a/dmrg/Engine/TargetParamsTimeVectors.h
+++ b/dmrg/Engine/TargetParamsTimeVectors.h
@@ -132,19 +132,19 @@ public:
 		} catch (std::exception&) { }
 	}
 
-	virtual VectorRealType& times() { return times_; }
+	VectorRealType& times() override { return times_; }
 
-	virtual const VectorRealType& times() const { return times_; }
+	const VectorRealType& times() const override { return times_; }
 
-	virtual SizeType advanceEach() const { return advanceEach_; }
+	SizeType advanceEach() const override { return advanceEach_; }
 
-	virtual typename BaseType::AlgorithmEnum algorithm() const { return algorithm_; }
+	typename BaseType::AlgorithmEnum algorithm() const override { return algorithm_; }
 
-	virtual RealType tau() const { return tau_; }
+	RealType tau() const override { return tau_; }
 
-	virtual RealType timeDirection() const { return timeDirection_; }
+	RealType timeDirection() const override { return timeDirection_; }
 
-	virtual const VectorRealType& chebyTransform() const { return chebyTransform_; }
+	const VectorRealType& chebyTransform() const override { return chebyTransform_; }
 
 	template <typename IoInputter>
 	void setAlgorithm(VectorRealType* chebyTransform, PsimagLite::String s, IoInputter* io)

--- a/dmrg/Engine/TargetingCVEvolution.h
+++ b/dmrg/Engine/TargetingCVEvolution.h
@@ -162,27 +162,27 @@ public:
 			weight_[i] = factor;
 	}
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const
+	SizeType targets() const override
 	{
 		return PsimagLite::IsComplexNumber<ComplexOrRealType>::True ? 3 : 5;
 	}
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(!this->common().aoe().allStages(StageEnumType::DISABLED));
 		return weight_[i];
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		if (this->common().aoe().allStages(StageEnumType::DISABLED))
 			return 1.0;
 		return gsWeight_;
 	}
 
-	bool includeGroundStage() const
+	bool includeGroundStage() const override
 	{
 		if (!this->common().aoe().noStageIs(StageEnumType::DISABLED))
 			return true;
@@ -194,7 +194,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&,
-	            SizeType loopNumber)
+	            SizeType loopNumber) override
 	{
 		assert(block1.size() > 0);
 		SizeType site = block1[0];
@@ -219,16 +219,16 @@ public:
 		evolveInternal(Eg, direction, block, loopNumber);
 	}
 
-	bool end() const { return (almostDone_ >= 2); }
+	bool end() const override { return (almostDone_ >= 2); }
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "CVEvolution");
 	}
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		PsimagLite::OstringStream                     msgg(std::cout.precision());
 		PsimagLite::OstringStream::OstringStreamType& msg = msgg();

--- a/dmrg/Engine/TargetingChebyshev.h
+++ b/dmrg/Engine/TargetingChebyshev.h
@@ -181,24 +181,24 @@ public:
 		this->common().aoeNonConst().initTimeVectors(tstStruct_, ioIn);
 	}
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return tstStruct_.times().size(); }
+	SizeType targets() const override { return tstStruct_.times().size(); }
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(!this->common().aoe().allStages(StageEnumType::DISABLED));
 		return weight_[i];
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		if (this->common().aoe().allStages(StageEnumType::DISABLED))
 			return 1.0;
 		return gsWeight_;
 	}
 
-	bool includeGroundStage() const
+	bool includeGroundStage() const override
 	{
 		if (!this->common().aoe().noStageIs(StageEnumType::DISABLED))
 			return true;
@@ -210,7 +210,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&,
-	            SizeType loopNumber)
+	            SizeType loopNumber) override
 	{
 		assert(energies.size() > 0);
 		RealType Eg = energies[0];
@@ -219,20 +219,20 @@ public:
 		this->common().cocoon(block1, direction, doBorderIfBorder); // in-situ
 	}
 
-	bool end() const
+	bool end() const override
 	{
 		return (tstStruct_.maxTime() != 0
 		        && this->common().aoe().timeVectors().time() >= tstStruct_.maxTime());
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "Chebyshev");
 	}
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		PsimagLite::OstringStream                     msgg(std::cout.precision());
 		PsimagLite::OstringStream::OstringStreamType& msg = msgg();

--- a/dmrg/Engine/TargetingCorrection.h
+++ b/dmrg/Engine/TargetingCorrection.h
@@ -129,16 +129,16 @@ public:
 	    , progress_("TargetingCorrection")
 	{ }
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return 1; }
+	SizeType targets() const override { return 1; }
 
-	RealType normSquared(SizeType i) const
+	RealType normSquared(SizeType i) const override
 	{
 		return PsimagLite::real(this->tv(i) * this->tv(i));
 	}
 
-	RealType weight(SizeType) const
+	RealType weight(SizeType) const override
 	{
 		assert(this->common().aoe().noStageIs(StageEnumType::DISABLED));
 		RealType gsWeight = 1;
@@ -147,7 +147,7 @@ public:
 		return weight1;
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		RealType gsWeight = 1;
 		RealType weight   = 0;
@@ -159,7 +159,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&,
-	            SizeType)
+	            SizeType) override
 	{
 		if (direction == ProgramGlobals::DirectionEnum::INFINITE)
 			return;
@@ -170,14 +170,14 @@ public:
 		this->common().cocoon(block1, direction, doBorderIfBorder);
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().read(io, prefix);
 	}
 
 	void write(const typename PsimagLite::Vector<SizeType>::Type& block,
 	           PsimagLite::IoSelector::Out&                       io,
-	           PsimagLite::String                                 prefix) const
+	           PsimagLite::String                                 prefix) const override
 	{
 		this->common().write(io, block, prefix);
 	}

--- a/dmrg/Engine/TargetingCorrectionVector.h
+++ b/dmrg/Engine/TargetingCorrectionVector.h
@@ -161,24 +161,24 @@ public:
 			err("TargetingCorrectionVector needs wft\n");
 	}
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return 4; }
+	SizeType targets() const override { return 4; }
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(i < weight_.size());
 		return weight_[i];
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		if (!correctionEnabled_)
 			return 1.0;
 		return gsWeight_;
 	}
 
-	SizeType size() const
+	SizeType size() const override
 	{
 		if (!correctionEnabled_)
 			return 0;
@@ -189,7 +189,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&              block2,
-	            SizeType                      loopNumber)
+	            SizeType                      loopNumber) override
 	{
 		if (block1.size() != 1 || block2.size() != 1) {
 			PsimagLite::String str(__FILE__);
@@ -221,13 +221,13 @@ public:
 
 	void write(const typename PsimagLite::Vector<SizeType>::Type& block,
 	           PsimagLite::IoSelector::Out&                       io,
-	           PsimagLite::String                                 prefix) const
+	           PsimagLite::String                                 prefix) const override
 	{
 		this->common().write(io, block, prefix);
 		this->common().writeNGSTs(io, prefix, block, "CorrectionVector");
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "CorrectionVector");
 		setWeights();

--- a/dmrg/Engine/TargetingDynamic.h
+++ b/dmrg/Engine/TargetingDynamic.h
@@ -149,17 +149,17 @@ public:
 			err(" TargetingDynamic needs an enabled wft\n");
 	}
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return 0; }
+	SizeType targets() const override { return 0; }
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(!this->common().aoe().allStages(StageEnumType::DISABLED));
 		return weight_[i];
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		if (this->common().aoe().allStages(StageEnumType::DISABLED))
 			return 1.0;
@@ -170,7 +170,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&              block2,
-	            SizeType                      loopNumber)
+	            SizeType                      loopNumber) override
 	{
 		if (block1.size() != 1 || block2.size() != 1) {
 			PsimagLite::String str(__FILE__);
@@ -200,7 +200,7 @@ public:
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		this->common().write(io, block, prefix);
 
@@ -226,7 +226,7 @@ public:
 		this->common().writeNGSTs(io, prefix, block, "Dynamic", cf);
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "Dynamic");
 	}

--- a/dmrg/Engine/TargetingExpression.h
+++ b/dmrg/Engine/TargetingExpression.h
@@ -141,29 +141,29 @@ public:
 		io.readline(gsWeight_, "GsWeight=");
 	}
 
-	SizeType sites() const { return 0; }
+	SizeType sites() const override { return 0; }
 
-	SizeType targets() const { return pvectors_.targets(); }
+	SizeType targets() const override { return pvectors_.targets(); }
 
-	RealType normSquared(SizeType i) const
+	RealType normSquared(SizeType i) const override
 	{
 		return PsimagLite::real(this->tv(i) * this->tv(i));
 	}
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(this->common().aoe().noStageIs(StageEnumType::DISABLED));
 		assert(i < weights_.size());
 		return weights_[i];
 	}
 
-	RealType gsWeight() const { return gsWeightActual_; }
+	RealType gsWeight() const override { return gsWeightActual_; }
 
 	void evolve(const VectorRealType&         energies,
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&,
-	            SizeType loopNumber)
+	            SizeType loopNumber) override
 	{
 		if (direction == ProgramGlobals::DirectionEnum::INFINITE)
 			return;
@@ -238,14 +238,14 @@ public:
 		evolve(energies, direction, block, block, loopNumber);
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "Expression");
 	}
 
 	void write(const typename PsimagLite::Vector<SizeType>::Type& block,
 	           PsimagLite::IoSelector::Out&                       io,
-	           PsimagLite::String                                 prefix) const
+	           PsimagLite::String                                 prefix) const override
 	{
 		this->common().write(io, block, prefix);
 		this->common().writeNGSTs(io, prefix, block, "Expression");

--- a/dmrg/Engine/TargetingGroundState.h
+++ b/dmrg/Engine/TargetingGroundState.h
@@ -133,16 +133,16 @@ public:
 	    , progress_("TargetingGroundState")
 	{ }
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return 0; }
+	SizeType targets() const override { return 0; }
 
-	RealType weight(SizeType) const
+	RealType weight(SizeType) const override
 	{
 		throw PsimagLite::RuntimeError("GST: What are you doing here?\n");
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		const VectorVectorVectorWithOffsetType& v = this->common().aoe().psiConst();
 		const SizeType                          n = v.size();
@@ -163,13 +163,13 @@ public:
 		return 1.0 / sum;
 	}
 
-	SizeType size() const { return 0; }
+	SizeType size() const override { return 0; }
 
 	void evolve(const VectorRealType&,
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&,
-	            SizeType)
+	            SizeType) override
 	{
 		bool doBorderIfBorder = true;
 		this->common().cocoon(block1, direction, doBorderIfBorder);
@@ -177,12 +177,12 @@ public:
 
 	void write(const typename PsimagLite::Vector<SizeType>::Type& block,
 	           PsimagLite::IoSelector::Out&                       io,
-	           PsimagLite::String                                 prefix) const
+	           PsimagLite::String                                 prefix) const override
 	{
 		this->common().write(io, block, prefix);
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "GroundState");
 	}

--- a/dmrg/Engine/TargetingMetts.h
+++ b/dmrg/Engine/TargetingMetts.h
@@ -203,7 +203,7 @@ public:
 		this->common().aoeNonConst().initTimeVectors(mettsStruct_, ioIn);
 	}
 
-	~TargetingMetts()
+	~TargetingMetts() override
 	{
 		SizeType n = garbage_.size();
 		for (SizeType i = 0; i < n; ++i) {
@@ -212,17 +212,17 @@ public:
 		}
 	}
 
-	SizeType sites() const { return mettsStruct_.sites(); }
+	SizeType sites() const override { return mettsStruct_.sites(); }
 
-	SizeType targets() const { return mettsStruct_.times().size() + 1; }
+	SizeType targets() const override { return mettsStruct_.times().size() + 1; }
 
-	RealType weight(SizeType i) const { return weight_[i]; }
+	RealType weight(SizeType i) const override { return weight_[i]; }
 
-	RealType gsWeight() const { return gsWeight_; }
+	RealType gsWeight() const override { return gsWeight_; }
 
-	bool includeGroundStage() const { return (fabs(gsWeight_) > 1e-6); }
+	bool includeGroundStage() const override { return (fabs(gsWeight_) > 1e-6); }
 
-	SizeType size() const
+	SizeType size() const override
 	{
 		if (this->common().aoe().allStages(StageEnumType::DISABLED))
 			return 1;
@@ -236,7 +236,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&              block2,
-	            SizeType                      loopNumber)
+	            SizeType                      loopNumber) override
 	{
 		RealType Eg = 0;
 
@@ -312,14 +312,14 @@ public:
 		}
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "Metts");
 	}
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		this->common().write(io, block, prefix);
 
@@ -333,12 +333,12 @@ public:
 		this->common().writeNGSTs(io, prefix, block, "Metts");
 	}
 
-	void updateOnSiteForCorners(BasisWithOperatorsType&) const
+	void updateOnSiteForCorners(BasisWithOperatorsType&) const override
 	{
 		// nothing to do here
 	}
 
-	bool end() const { return false; }
+	bool end() const override { return false; }
 
 private:
 

--- a/dmrg/Engine/TargetingRixsDynamic.h
+++ b/dmrg/Engine/TargetingRixsDynamic.h
@@ -195,20 +195,20 @@ public:
 		this->common().aoeNonConst().initTimeVectors(*tstStruct2_, ioIn);
 	}
 
-	~TargetingRixsDynamic()
+	~TargetingRixsDynamic() override
 	{
 		delete tstStruct2_;
 		tstStruct2_ = nullptr;
 	}
 
-	SizeType sites() const
+	SizeType sites() const override
 	{
 		return (tstStruct_.algorithm() == TargetParamsType::BaseType::AlgorithmEnum::KRYLOV)
 		    ? tstStruct_.sites()
 		    : tstStruct2_->sites();
 	}
 
-	SizeType targets() const
+	SizeType targets() const override
 	{
 		const AlgorithmEnumType algo = tstStruct_.algorithm();
 		if (algo == TargetParamsType::BaseType::AlgorithmEnum::KRYLOV) {
@@ -220,15 +220,15 @@ public:
 		}
 	}
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(i < weight_.size());
 		return weight_[i];
 	}
 
-	RealType gsWeight() const { return gsWeightActual_; }
+	RealType gsWeight() const override { return gsWeightActual_; }
 
-	SizeType size() const
+	SizeType size() const override
 	{
 		if (!applied_ && appliedFirst_)
 			return 8;
@@ -257,7 +257,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&              block2,
-	            SizeType                      loopNumber)
+	            SizeType                      loopNumber) override
 	{
 		if (block1.size() != 1 || block2.size() != 1) {
 			PsimagLite::String str(__FILE__);
@@ -330,13 +330,13 @@ public:
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		this->common().write(io, block, prefix);
 		this->common().writeNGSTs(io, prefix, block, "RixsDynamic");
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().read(io, prefix);
 

--- a/dmrg/Engine/TargetingRixsStatic.h
+++ b/dmrg/Engine/TargetingRixsStatic.h
@@ -165,15 +165,15 @@ public:
 			err("TargetingRixsStatic needs wft\n");
 	}
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return 6; }
+	SizeType targets() const override { return 6; }
 
-	RealType weight(SizeType i) const { return weight_[i]; }
+	RealType weight(SizeType i) const override { return weight_[i]; }
 
-	RealType gsWeight() const { return gsWeight_; }
+	RealType gsWeight() const override { return gsWeight_; }
 
-	SizeType size() const
+	SizeType size() const override
 	{
 		if (!applied_ && appliedFirst_) {
 			return 4;
@@ -185,7 +185,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&              block2,
-	            SizeType                      loopNumber)
+	            SizeType                      loopNumber) override
 	{
 		if (block1.size() != 1 || block2.size() != 1) {
 			PsimagLite::String str(__FILE__);
@@ -203,13 +203,13 @@ public:
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		this->common().write(io, block, prefix);
 		this->common().writeNGSTs(io, prefix, block, "RixsStatic");
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().read(io, prefix);
 

--- a/dmrg/Engine/TargetingTimeStep.h
+++ b/dmrg/Engine/TargetingTimeStep.h
@@ -169,24 +169,24 @@ public:
 		this->common().aoeNonConst().initTimeVectors(tstStruct_, ioIn);
 	}
 
-	SizeType sites() const { return tstStruct_.sites(); }
+	SizeType sites() const override { return tstStruct_.sites(); }
 
-	SizeType targets() const { return tstStruct_.times().size(); }
+	SizeType targets() const override { return tstStruct_.times().size(); }
 
-	RealType weight(SizeType i) const
+	RealType weight(SizeType i) const override
 	{
 		assert(!this->common().aoe().allStages(StageEnumType::DISABLED));
 		return weight_[i];
 	}
 
-	RealType gsWeight() const
+	RealType gsWeight() const override
 	{
 		if (this->common().aoe().allStages(StageEnumType::DISABLED))
 			return 1.0;
 		return gsWeight_;
 	}
 
-	bool includeGroundStage() const
+	bool includeGroundStage() const override
 	{
 		if (!this->common().aoe().noStageIs(StageEnumType::DISABLED))
 			return true;
@@ -198,7 +198,7 @@ public:
 	            ProgramGlobals::DirectionEnum direction,
 	            const BlockType&              block1,
 	            const BlockType&,
-	            SizeType loopNumber)
+	            SizeType loopNumber) override
 	{
 		assert(block1.size() > 0);
 		SizeType site = block1[0];
@@ -224,20 +224,20 @@ public:
 		evolveInternal(Eg, direction, block, loopNumber);
 	}
 
-	bool end() const
+	bool end() const override
 	{
 		return (tstStruct_.maxTime() != 0
 		        && this->common().aoe().timeVectors().time() >= tstStruct_.maxTime());
 	}
 
-	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix)
+	void read(typename TargetingCommonType::IoInputType& io, PsimagLite::String prefix) override
 	{
 		this->common().readGSandNGSTs(io, prefix, "TimeStep");
 	}
 
 	void write(const VectorSizeType&        block,
 	           PsimagLite::IoSelector::Out& io,
-	           PsimagLite::String           prefix) const
+	           PsimagLite::String           prefix) const override
 	{
 		PsimagLite::OstringStream                     msgg(std::cout.precision());
 		PsimagLite::OstringStream::OstringStreamType& msg = msgg();

--- a/dmrg/Engine/TimeVectorsChebyshev.h
+++ b/dmrg/Engine/TimeVectorsChebyshev.h
@@ -181,10 +181,10 @@ public:
 		}
 	}
 
-	virtual void calcTimeVectors(const VectorSizeType&               indices,
-	                             RealType                            Eg,
-	                             const VectorWithOffsetType&         phi,
-	                             const typename BaseType::ExtraData& extra)
+	void calcTimeVectors(const VectorSizeType&               indices,
+	                     RealType                            Eg,
+	                     const VectorWithOffsetType&         phi,
+	                     const typename BaseType::ExtraData& extra) override
 	{
 		const VectorRealType& times = tstStruct_.times();
 
@@ -284,7 +284,7 @@ public:
 		timeHasAdvanced_ = false;
 	}
 
-	void timeHasAdvanced()
+	void timeHasAdvanced() override
 	{
 		timeHasAdvanced_ = true;
 		this->advanceCurrentTime(tstStruct_.tau());

--- a/dmrg/Engine/TimeVectorsKrylov.h
+++ b/dmrg/Engine/TimeVectorsKrylov.h
@@ -162,10 +162,10 @@ public:
 	    , krylovHelper_(model.params(), 0)
 	{ }
 
-	virtual void calcTimeVectors(const PsimagLite::Vector<SizeType>::Type& indices,
-	                             RealType                                  Eg,
-	                             const VectorWithOffsetType&               phi,
-	                             const typename BaseType::ExtraData&       extra)
+	void calcTimeVectors(const PsimagLite::Vector<SizeType>::Type& indices,
+	                     RealType                                  Eg,
+	                     const VectorWithOffsetType&               phi,
+	                     const typename BaseType::ExtraData&       extra) override
 	{
 		const VectorRealType& times = tstStruct_.times();
 
@@ -231,7 +231,7 @@ public:
 			timeHasAdvanced_ = false;
 	}
 
-	void timeHasAdvanced()
+	void timeHasAdvanced() override
 	{
 		timeHasAdvanced_ = true;
 		this->advanceCurrentTime(tstStruct_.tau());

--- a/dmrg/Engine/TimeVectorsRungeKutta.h
+++ b/dmrg/Engine/TimeVectorsRungeKutta.h
@@ -138,10 +138,10 @@ public:
 	    , lrs_(lrs)
 	{ }
 
-	virtual void calcTimeVectors(const VectorSizeType&       indices,
-	                             RealType                    Eg,
-	                             const VectorWithOffsetType& phi,
-	                             const typename BaseType::ExtraData&)
+	void calcTimeVectors(const VectorSizeType&       indices,
+	                     RealType                    Eg,
+	                     const VectorWithOffsetType& phi,
+	                     const typename BaseType::ExtraData&) override
 	{
 		PsimagLite::OstringStream                     msgg(std::cout.precision());
 		PsimagLite::OstringStream::OstringStreamType& msg = msgg();

--- a/dmrg/Engine/TimeVectorsSuzukiTrotter.h
+++ b/dmrg/Engine/TimeVectorsSuzukiTrotter.h
@@ -141,10 +141,10 @@ public:
 	    , twoSiteDmrg_(wft_.options().twoSiteDmrg)
 	{ }
 
-	virtual void calcTimeVectors(const VectorSizeType&               indices,
-	                             RealType                            Eg,
-	                             const VectorWithOffsetType&         phi,
-	                             const typename BaseType::ExtraData& extraData)
+	void calcTimeVectors(const VectorSizeType&               indices,
+	                     RealType                            Eg,
+	                     const VectorWithOffsetType&         phi,
+	                     const typename BaseType::ExtraData& extraData) override
 	{
 		PsimagLite::OstringStream                     msgg(std::cout.precision());
 		PsimagLite::OstringStream::OstringStreamType& msg = msgg();
@@ -258,7 +258,7 @@ public:
 		}
 	}
 
-	void timeHasAdvanced()
+	void timeHasAdvanced() override
 	{
 		linksSeen_.clear();
 		PsimagLite::OstringStream                     msgg(std::cout.precision());

--- a/dmrg/Engine/Wft/WaveFunctionTransfLocal.h
+++ b/dmrg/Engine/Wft/WaveFunctionTransfLocal.h
@@ -144,10 +144,10 @@ public:
 	    , wftAccelSvd_(dmrgWaveStruct, wftOptions)
 	{ }
 
-	virtual void transformVector(VectorWithOffsetType&       psiDest,
-	                             const VectorWithOffsetType& psiSrc,
-	                             const LeftRightSuperType&   lrs,
-	                             const OneSiteSpacesType&    oneSiteSpaces) const
+	void transformVector(VectorWithOffsetType&       psiDest,
+	                     const VectorWithOffsetType& psiSrc,
+	                     const LeftRightSuperType&   lrs,
+	                     const OneSiteSpacesType&    oneSiteSpaces) const override
 
 	{
 		PsimagLite::Profiling profiling("WFT", std::cout);

--- a/dmrg/Models/ExtendedHubbard1Orb/ExtendedHubbard1Orb.h
+++ b/dmrg/Models/ExtendedHubbard1Orb/ExtendedHubbard1Orb.h
@@ -125,7 +125,7 @@ public:
 	    , modelHubbard_(solverParams, io, geometry, extension)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -136,21 +136,21 @@ public:
 		modelHubbard_.write(label, io);
 	}
 
-	virtual void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
-	                                        const BlockType&  block,
-	                                        RealType          time) const
+	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
+	                                const BlockType&  block,
+	                                RealType          time) const override
 	{
 		modelHubbard_.addDiagonalsInNaturalBasis(hmatrix, block, time);
 	}
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		modelHubbard_.fillLabeledOperators(qns);
 
 		this->makeTrackable("n");
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		modelHubbard_.fillModelLinks();
 

--- a/dmrg/Models/FeAsBasedScExtended/FeAsBasedScExtended.h
+++ b/dmrg/Models/FeAsBasedScExtended/FeAsBasedScExtended.h
@@ -129,7 +129,7 @@ public:
 	    , orbitals_(modelParameters_.orbitals)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -141,16 +141,16 @@ public:
 		io.write(label + "/orbitals_", orbitals_);
 	}
 
-	virtual void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
-	                                        const BlockType&  block,
-	                                        RealType          time) const
+	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
+	                                const BlockType&  block,
+	                                RealType          time) const override
 	{
 		modelFeAs_.addDiagonalsInNaturalBasis(hmatrix, block, time);
 	}
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		modelFeAs_.fillLabeledOperators(qns);
 		SizeType                                        site = 0;
@@ -179,7 +179,7 @@ protected:
 		this->makeTrackable("naturalSz");
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		modelFeAs_.fillModelLinks();
 

--- a/dmrg/Models/FeAsModel/ModelFeBasedSc.h
+++ b/dmrg/Models/FeAsModel/ModelFeBasedSc.h
@@ -309,7 +309,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -332,7 +332,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
@@ -352,7 +352,7 @@ public:
 		}
 	}
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		qns = qq_;
 		assert(creationMatrix_.size() > 0);
@@ -476,7 +476,7 @@ public:
 	$t(orb1, orb2)$, and must be as
 	3rd number of each operator, respectively.
 	 */
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		const SizeType orbitals = modelParameters_.orbitals;
 		ModelTermType& hop      = ModelBaseType::createTerm("hopping"); //(A)

--- a/dmrg/Models/FermionSpinless/FermionSpinless.h
+++ b/dmrg/Models/FermionSpinless/FermionSpinless.h
@@ -169,7 +169,7 @@ public:
 			err("FermionSpinless: Both or none of TSPTau= and TSPMu= must appear\n");
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -184,7 +184,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		static bool firstCall = true;
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
@@ -225,7 +225,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType         site = 0;
 		BlockType        block(1, site);
@@ -276,7 +276,7 @@ protected:
 		this->makeTrackable("n");
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hop  = ModelBaseType::createTerm("hopping");
 		ModelTermType& ninj = ModelBaseType::createTerm("ninj");

--- a/dmrg/Models/GaugeSpin/GaugeSpin.h
+++ b/dmrg/Models/GaugeSpin/GaugeSpin.h
@@ -136,7 +136,7 @@ public:
 	    , superOpHelperPlaquette_(nullptr)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -148,7 +148,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -168,7 +168,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		const SizeType   total = TWICE_THE_SPIN + 1;
 		HilbertBasisType natBasis(total);
@@ -216,7 +216,7 @@ protected:
 		this->makeTrackable("sx");
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		if (BasisType::useSu2Symmetry())
 			err("SU(2): no longer supported\n");
@@ -231,7 +231,7 @@ protected:
 
 	void fillNewNonLocals(std::vector<OperatorType>& newNonLocals,
 	                      const LeftRightSuperType&  lrs,
-	                      RealType) const // last argument is time
+	                      RealType) const override // last argument is time
 	{
 		bool isSys = (lrs.super().block()[0] == 0);
 		if (isSys) {
@@ -258,7 +258,7 @@ protected:
 		}
 	}
 
-	SuperOpHelperBaseType* setSuperOpHelper()
+	SuperOpHelperBaseType* setSuperOpHelper() override
 	{
 		if (!superOpHelperPlaquette_)
 			superOpHelperPlaquette_

--- a/dmrg/Models/GaugeSpin/SuperOpHelperPlaquette.h
+++ b/dmrg/Models/GaugeSpin/SuperOpHelperPlaquette.h
@@ -40,7 +40,9 @@ public:
 	    , newSite_(0)
 	{ }
 
-	void setToProduct(SizeType smaxOrEmin, SizeType newSite, ProgramGlobals::DirectionEnum dir)
+	void setToProduct(SizeType                      smaxOrEmin,
+	                  SizeType                      newSite,
+	                  ProgramGlobals::DirectionEnum dir) override
 	{
 		smaxOrEmin_ = smaxOrEmin;
 		newSite_    = newSite;
@@ -53,11 +55,11 @@ public:
 	// This below is for a plaquette, and will have to be
 	// written somewhere else
 	// testing devel FIXME TODO
-	SizeType size() const { return 1; }
+	SizeType size() const override { return 1; }
 
 	PairMetaOpForConnection finalIndices(const VectorSizeType&          hItems,
 	                                     ProgramGlobals::ConnectionEnum type,
-	                                     SizeType                       rightBlockSize) const
+	                                     SizeType rightBlockSize) const override
 	{
 		assert(hItems.size() == 4);
 		constexpr int NON_LOCAL = -1;
@@ -97,7 +99,7 @@ public:
 		throw PsimagLite::RuntimeError("How to encode two plaquettes: depends on hItems\n");
 	}
 
-	PairBoolSizeType leftOperatorIndex(SizeType) const
+	PairBoolSizeType leftOperatorIndex(SizeType) const override
 	{
 		if (isTriangle_) {
 			if (BaseType::dir() == ProgramGlobals::DirectionEnum::EXPAND_SYSTEM) {
@@ -110,7 +112,7 @@ public:
 		return PairBoolSizeType(false, 0);
 	}
 
-	PairBoolSizeType rightOperatorIndex(SizeType) const
+	PairBoolSizeType rightOperatorIndex(SizeType) const override
 	{
 		if (isTriangle_) {
 			if (BaseType::dir() == ProgramGlobals::DirectionEnum::EXPAND_SYSTEM) {

--- a/dmrg/Models/Graphene/Graphene.h
+++ b/dmrg/Models/Graphene/Graphene.h
@@ -148,7 +148,7 @@ public:
 		setOperatorMatricesInternal(creationMatrix_, block);
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -164,7 +164,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -176,7 +176,7 @@ public:
 		}
 	}
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		qns = qq_;
 		assert(creationMatrix_.size() > 0);
@@ -304,7 +304,7 @@ public:
 	/* PSIDOC Graphene::fillModelLinks
 	  Write DOC here TBW FIXME TODO
 	 */
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		const SizeType orbitals = modelParameters_.orbitals;
 		ModelTermType& hopA     = ModelBaseType::createTerm("hoppingA");

--- a/dmrg/Models/Heisenberg/HeisenbergMix.h
+++ b/dmrg/Models/Heisenberg/HeisenbergMix.h
@@ -146,12 +146,12 @@ public:
 		    : n_(n)
 		{ }
 
-		virtual SizeType siteToAtomKind(SizeType site) const
+		SizeType siteToAtomKind(SizeType site) const override
 		{
 			return (site == 0 || site == n_ - 1) ? 1 : 0;
 		}
 
-		virtual SizeType kindsOfAtoms() const { return 2; }
+		SizeType kindsOfAtoms() const override { return 2; }
 
 	private:
 
@@ -195,13 +195,13 @@ public:
 		}
 	}
 
-	~HeisenbergMix()
+	~HeisenbergMix() override
 	{
 		delete atomKind_;
 		atomKind_ = nullptr;
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -219,7 +219,7 @@ public:
 	 */
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -266,14 +266,14 @@ public:
 
 protected:
 
-	virtual const AtomKindBaseType& getAtomKind()
+	const AtomKindBaseType& getAtomKind() override
 	{
 		if (!atomKind_)
 			atomKind_ = new AtomKind(superGeometry_.numberOfSites());
 		return *atomKind_;
 	}
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		qns.clear();
 		SizeType offset = fillLabeledOperators(qns, 0, SiteType::SITE_MIDDLE);
@@ -340,7 +340,7 @@ protected:
 		return natBasis.size();
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		if (BasisType::useSu2Symmetry())
 			err("SU(2) not supported\n");

--- a/dmrg/Models/Heisenberg/ModelHeisenberg.h
+++ b/dmrg/Models/Heisenberg/ModelHeisenberg.h
@@ -164,7 +164,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -184,7 +184,7 @@ public:
 	 */
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -231,7 +231,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType  site = 0;
 		BlockType block(1, site);
@@ -315,7 +315,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		if (additional_ == "2") {
 			fillModelLinks2();

--- a/dmrg/Models/HeisenbergAncillaC/HeisenbergAncillaC.h
+++ b/dmrg/Models/HeisenbergAncillaC/HeisenbergAncillaC.h
@@ -166,7 +166,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -179,7 +179,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -198,7 +198,7 @@ public:
 		}
 	}
 
-	virtual PsimagLite::String oracle() const
+	PsimagLite::String oracle() const override
 	{
 		const RealType nup    = ModelBaseType::targetQuantum().qn(0).other[0];
 		const RealType n      = ModelBaseType::superGeometry().numberOfSites();
@@ -208,7 +208,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 
 		if (modelParameters_.twiceTheSpin > 2)
@@ -312,7 +312,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		const bool isSu2 = BasisType::useSu2Symmetry();
 

--- a/dmrg/Models/HolsteinSpinlessThin/HolsteinSpinlessThin.h
+++ b/dmrg/Models/HolsteinSpinlessThin/HolsteinSpinlessThin.h
@@ -140,9 +140,9 @@ public:
 
 	public:
 
-		virtual SizeType siteToAtomKind(SizeType site) const { return (site & 1); }
+		SizeType siteToAtomKind(SizeType site) const override { return (site & 1); }
 
-		virtual SizeType kindsOfAtoms() const { return 2; }
+		SizeType kindsOfAtoms() const override { return 2; }
 	};
 
 	static const int FERMION_SIGN = -1;
@@ -161,7 +161,7 @@ public:
 			err("SSH not supported in thin version yet!\n");
 	}
 
-	~HolsteinSpinlessThin()
+	~HolsteinSpinlessThin() override
 	{
 		delete atomKind_;
 		atomKind_ = nullptr;
@@ -171,7 +171,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -194,7 +194,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -206,14 +206,14 @@ public:
 
 protected:
 
-	virtual const AtomKindBaseType& getAtomKind()
+	const AtomKindBaseType& getAtomKind() override
 	{
 		if (!atomKind_)
 			atomKind_ = new AtomKind();
 		return *atomKind_;
 	}
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		OpsLabelType& c = this->createOpsLabel("c", 1); // 1 == fermionic site
 		OpsLabelType& a = this->createOpsLabel("a", 0); // 0 == bosonic site
@@ -306,7 +306,7 @@ protected:
 		                       su2Related3));
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hopf = ModelBaseType::createTerm("HoppingFermionic");
 

--- a/dmrg/Models/HolsteinThin/HolsteinThin.h
+++ b/dmrg/Models/HolsteinThin/HolsteinThin.h
@@ -139,9 +139,9 @@ public:
 
 	public:
 
-		virtual SizeType siteToAtomKind(SizeType site) const { return (site & 1); }
+		SizeType siteToAtomKind(SizeType site) const override { return (site & 1); }
 
-		virtual SizeType kindsOfAtoms() const { return 2; }
+		SizeType kindsOfAtoms() const override { return 2; }
 	};
 
 	static const int FERMION_SIGN = -1;
@@ -161,7 +161,7 @@ public:
 			err("SSH not supported in thin version yet!\n");
 	}
 
-	~HolsteinThin()
+	~HolsteinThin() override
 	{
 		delete atomKind_;
 		atomKind_ = nullptr;
@@ -171,7 +171,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -195,7 +195,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -207,14 +207,14 @@ public:
 
 protected:
 
-	virtual const AtomKindBaseType& getAtomKind()
+	const AtomKindBaseType& getAtomKind() override
 	{
 		if (!atomKind_)
 			atomKind_ = new AtomKind();
 		return *atomKind_;
 	}
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		OpsLabelType& c = this->createOpsLabel("c", 1); // 1 == fermionic site
 		OpsLabelType& a = this->createOpsLabel("a", 0); // 0 == bosonic site
@@ -388,7 +388,7 @@ protected:
 		                       su2Related2));
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hopf = ModelBaseType::createTerm("HoppingFermionic");
 

--- a/dmrg/Models/HubbardAncilla/HubbardAncilla.h
+++ b/dmrg/Models/HubbardAncilla/HubbardAncilla.h
@@ -141,19 +141,19 @@ public:
 	    , helperHubbardAncilla_(superGeometry_, modelParameters_)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		helperHubbardAncilla_.write(label1, io, this->params().model);
 	}
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          t) const
+	                                RealType          t) const override
 	{
 		helperHubbardAncilla_.addDiagonalsInNaturalBasis(hmatrix, block, t);
 	}
 
-	virtual PsimagLite::String oracle() const
+	PsimagLite::String oracle() const override
 	{
 		const RealType ne     = ModelBaseType::targetQuantum().qn(0).other[0];
 		const RealType nup    = ModelBaseType::targetQuantum().qn(0).other[1];
@@ -165,7 +165,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType         site = 0; // FIXME for Immm SDHS
 		BlockType        block(1, site);
@@ -240,7 +240,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hop = ModelBaseType::createTerm("hopping");
 		ModelTermType& ll  = ModelBaseType::createTerm("LambdaLambda");

--- a/dmrg/Models/HubbardAncillaExtended/HubbardAncillaExtended.h
+++ b/dmrg/Models/HubbardAncillaExtended/HubbardAncillaExtended.h
@@ -141,21 +141,21 @@ public:
 	    , helperHubbardAncilla_(geometry, modelParameters_)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		helperHubbardAncilla_.write(label1, io, this->params().model);
 	}
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          t) const
+	                                RealType          t) const override
 	{
 		helperHubbardAncilla_.addDiagonalsInNaturalBasis(hmatrix, block, t);
 	}
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType         site = 0;
 		BlockType        block(1, site);
@@ -236,7 +236,7 @@ protected:
 		//			assert(creationMatrix.size() == 8);
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		const SizeType orbitals = (helperHubbardAncilla_.isHot()) ? 2 : 1;
 		const bool     isSu2    = BasisType::useSu2Symmetry();

--- a/dmrg/Models/HubbardHolstein/HubbardHolstein.h
+++ b/dmrg/Models/HubbardHolstein/HubbardHolstein.h
@@ -165,7 +165,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -194,7 +194,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -211,7 +211,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType  site = 0;
 		BlockType block(1, site);
@@ -436,7 +436,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hopf = ModelBaseType::createTerm("HoppingFermionic");
 
@@ -484,7 +484,7 @@ protected:
 		}
 	}
 
-	void announce(PsimagLite::String str) const
+	void announce(PsimagLite::String str) const override
 	{
 		const PsimagLite::String msg("finite loop");
 		const SizeType           l = msg.length();
@@ -500,7 +500,9 @@ protected:
 		wantsOneSiteTruncation_ = PsimagLite::atoi(tokens[1]);
 	}
 
-	void oneSiteTruncationUpdate(OutputFileOrNot& ioOut, const MatrixType& U, SizeType start)
+	void oneSiteTruncationUpdate(OutputFileOrNot&  ioOut,
+	                             const MatrixType& U,
+	                             SizeType          start) override
 	{
 		bool firstCall = (U_.rows() == 0);
 
@@ -526,8 +528,9 @@ protected:
 	}
 
 	// virtual override
-	SizeType
-	setOperatorMatrices(VectorOperatorType& ops, VectorQnType& qm, const BlockType& block) const
+	SizeType setOperatorMatrices(VectorOperatorType& ops,
+	                             VectorQnType&       qm,
+	                             const BlockType&    block) const override
 	{
 		oStruncActive_ = false;
 

--- a/dmrg/Models/HubbardHolsteinSpinless/HubbardHolsteinSpinless.h
+++ b/dmrg/Models/HubbardHolsteinSpinless/HubbardHolsteinSpinless.h
@@ -165,7 +165,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -194,7 +194,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -211,7 +211,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType  site = 0;
 		BlockType block(1, site);
@@ -347,7 +347,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hopf = ModelBaseType::createTerm("HoppingFermionic");
 
@@ -387,7 +387,7 @@ protected:
 		}
 	}
 
-	void announce(PsimagLite::String str) const
+	void announce(PsimagLite::String str) const override
 	{
 		const PsimagLite::String msg("finite loop");
 		const SizeType           l = msg.length();
@@ -403,7 +403,9 @@ protected:
 		wantsOneSiteTruncation_ = PsimagLite::atoi(tokens[1]);
 	}
 
-	void oneSiteTruncationUpdate(OutputFileOrNot& ioOut, const MatrixType& U, SizeType start)
+	void oneSiteTruncationUpdate(OutputFileOrNot&  ioOut,
+	                             const MatrixType& U,
+	                             SizeType          start) override
 	{
 		bool firstCall = (U_.rows() == 0);
 
@@ -429,8 +431,9 @@ protected:
 	}
 
 	// virtual override
-	SizeType
-	setOperatorMatrices(VectorOperatorType& ops, VectorQnType& qm, const BlockType& block) const
+	SizeType setOperatorMatrices(VectorOperatorType& ops,
+	                             VectorQnType&       qm,
+	                             const BlockType&    block) const override
 	{
 		oStruncActive_ = false;
 

--- a/dmrg/Models/HubbardMultiBand/ModelHubbardMultiBand.h
+++ b/dmrg/Models/HubbardMultiBand/ModelHubbardMultiBand.h
@@ -165,7 +165,7 @@ public:
 		cacheInteractionOp();
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -183,7 +183,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -204,7 +204,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		qns = qq_;
 		assert(creationMatrix_.size() > 0);
@@ -295,7 +295,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 
 		//! There are orbitals*orbitals different orbitals

--- a/dmrg/Models/HubbardOneBand/ModelHubbard.h
+++ b/dmrg/Models/HubbardOneBand/ModelHubbard.h
@@ -176,7 +176,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType         site = 0;
 		BlockType        block(1, site);
@@ -337,7 +337,7 @@ protected:
 	Likewise, we create cdown in (D) and add the connection to \verb!hop! in (E)
 	PSIDOCCOPY $FirstFunctionBelow
 	*/
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		ModelTermType& hop = ModelBaseType::createTerm("hopping"); //(A)
 
@@ -383,7 +383,7 @@ protected:
 	and that's that. Here we write also some SU(2) auxiliary members in the last two lines.
 	PSIDOCCOPY $FirstFunctionBelow
 	 */
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1)) // (A)
 			io.createGroup(label1); // (B)
@@ -397,7 +397,7 @@ protected:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 

--- a/dmrg/Models/Immm/Immm.h
+++ b/dmrg/Models/Immm/Immm.h
@@ -166,7 +166,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -180,7 +180,7 @@ public:
 		io.write(label + "/statesOxygen_", statesOxygen_);
 	}
 
-	virtual SizeType maxElectronsOneSpin() const
+	SizeType maxElectronsOneSpin() const override
 	{
 		return NUMBER_OF_SPINS * ORBITALS_OXYGEN * superGeometry_.numberOfSites() + 1;
 	}
@@ -189,7 +189,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		for (SizeType site = 0; site < differentTypesOfAtoms(); ++site) {
 			OpsLabelType& c      = this->createOpsLabel("c", site);
@@ -257,7 +257,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks() { err("Immm is broken\n"); }
+	void fillModelLinks() override { err("Immm is broken\n"); }
 
 private:
 
@@ -426,7 +426,7 @@ private:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 

--- a/dmrg/Models/IsingMultiOrb/ModelIsingMultiOrb.h
+++ b/dmrg/Models/IsingMultiOrb/ModelIsingMultiOrb.h
@@ -167,7 +167,7 @@ public:
 		                                          orbs1);
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -182,7 +182,7 @@ public:
 	 */
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		//			ModelBaseType::additionalOnSiteHamiltonianFromFile(hmatrix,
 		// block, ii, data);
@@ -212,7 +212,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType         site = 0;
 		BlockType        block(1, site);
@@ -292,7 +292,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		if (BasisType::useSu2Symmetry())
 			err("SU(2) no longer supported\n");

--- a/dmrg/Models/Kitaev/Kitaev.h
+++ b/dmrg/Models/Kitaev/Kitaev.h
@@ -228,7 +228,7 @@ public:
 			err("Kitaev does not have SU(2) symmetry\n");
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -240,7 +240,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -281,7 +281,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType         site = 0;
 		BlockType        block(1, site);
@@ -368,7 +368,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 
 		if (withCharge_) {

--- a/dmrg/Models/Kondo/Kondo.h
+++ b/dmrg/Models/Kondo/Kondo.h
@@ -70,7 +70,7 @@ public:
 	// For information purposes only. Write model parameters
 	// String contains the group
 	// Serializer object is second argument
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -89,7 +89,7 @@ public:
 	// depend on it
 	void addDiagonalsInNaturalBasis(SparseMatrixType&     hmatrix,
 	                                const VectorSizeType& block,
-	                                RealType              time) const
+	                                RealType              time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -160,7 +160,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		qns = qn_;
 		assert(ops_.size() >= 5);
@@ -200,7 +200,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		const bool     isSu2 = BasisType::useSu2Symmetry();
 		ModelTermType& hop   = ModelBaseType::createTerm("hopping");

--- a/dmrg/Models/LiouvillianHeisenberg/LiouvillianHeisenberg.hh
+++ b/dmrg/Models/LiouvillianHeisenberg/LiouvillianHeisenberg.hh
@@ -139,7 +139,7 @@ public:
 		    modelParameters_.magneticFieldZ.size(), 'Z', n);
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -151,7 +151,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -176,7 +176,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType hilbert_small = modelParameters_.twiceTheSpin + 1; // = 2
 		SizeType hilbert_big
@@ -263,7 +263,7 @@ protected:
 		cacheJumpOperators();
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		// physical H
 		// Multiply by -i

--- a/dmrg/Models/SpinOrbital/SpinOrbitalModel.h
+++ b/dmrg/Models/SpinOrbital/SpinOrbitalModel.h
@@ -159,7 +159,7 @@ public:
 			    + "but not " + option + "\n");
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -171,7 +171,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -215,7 +215,7 @@ protected:
 	// ...
 	// (2s + 1)(2l + 1)    s      l
 	//
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		HilbertBasisType natBasis;
 		setBasis(natBasis);
@@ -558,7 +558,7 @@ protected:
 	// d        SzLz SzLz  N N
 	//
 	// more will be needed for J3L term
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		auto valueModiferTerm0 = [](ComplexOrRealType& value) { value *= 0.5; };
 		auto valueModiferTerm1 = [](ComplexOrRealType& value) { value *= 0.25; };

--- a/dmrg/Models/Su3/Su3Model.h
+++ b/dmrg/Models/Su3/Su3Model.h
@@ -146,13 +146,13 @@ public:
 		}
 	}
 
-	~Su3Model()
+	~Su3Model() override
 	{
 		delete su3Rep_;
 		su3Rep_ = nullptr;
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -165,7 +165,7 @@ public:
 	// m*T3(i)*T3(i) + m*T8(i)*T8(i)
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -192,7 +192,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		if (IS_REAL)
 			fillLabeledOperatorsReal(qns);
@@ -288,7 +288,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		if (IS_REAL)
 			fillModelLinksReal();

--- a/dmrg/Models/Su3/Su3RepresentationP1.h
+++ b/dmrg/Models/Su3/Su3RepresentationP1.h
@@ -11,7 +11,7 @@ public:
 
 	using MatrixType = PsimagLite::Matrix<ComplexOrRealType>;
 
-	void getMatrix(MatrixType& m, SizeType n) const
+	void getMatrix(MatrixType& m, SizeType n) const override
 	{
 		m.resize(3, 3);
 
@@ -48,7 +48,7 @@ public:
 	}
 
 	// diagonal 1 -1 0  ==> 2 0 1
-	SizeType t3OfState(SizeType ind) const
+	SizeType t3OfState(SizeType ind) const override
 	{
 		if (ind == 0)
 			return 2;
@@ -59,13 +59,13 @@ public:
 	}
 
 	// diagonal 1 1 -2 ==> 3 3 0
-	SizeType t8OfState(SizeType ind) const
+	SizeType t8OfState(SizeType ind) const override
 	{
 		assert(ind < 3);
 		return (ind < 2) ? 3 : 0;
 	}
 
-	SizeType size() const { return 3; }
+	SizeType size() const override { return 3; }
 };
 
 template <typename ComplexOrRealType>
@@ -77,7 +77,7 @@ public:
 	using RealType   = typename PsimagLite::Real<ComplexOrRealType>::Type;
 	using MatrixType = PsimagLite::Matrix<ComplexOrRealType>;
 
-	void getMatrix(MatrixType& m, SizeType n) const
+	void getMatrix(MatrixType& m, SizeType n) const override
 	{
 		m.resize(3, 3);
 
@@ -127,7 +127,7 @@ public:
 	}
 
 	// diagonal 1 -1 0  ==> 2 0 1
-	SizeType t3OfState(SizeType ind) const
+	SizeType t3OfState(SizeType ind) const override
 	{
 		if (ind == 0)
 			return 2;
@@ -138,13 +138,13 @@ public:
 	}
 
 	// diagonal 1 1 -2 ==> 3 3 0
-	SizeType t8OfState(SizeType ind) const
+	SizeType t8OfState(SizeType ind) const override
 	{
 		assert(ind < 3);
 		return (ind < 2) ? 3 : 0;
 	}
 
-	SizeType size() const { return 3; }
+	SizeType size() const override { return 3; }
 };
 
 #endif // SU3REPRESENTATIONP1_H

--- a/dmrg/Models/SuperExtendedHubbard1Orb/SuperExtendedHubbard1Orb.h
+++ b/dmrg/Models/SuperExtendedHubbard1Orb/SuperExtendedHubbard1Orb.h
@@ -129,7 +129,7 @@ public:
 	    , extendedHubbard_(solverParams, io, superGeometry, extension)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -140,16 +140,16 @@ public:
 		extendedHubbard_.write(label, io);
 	}
 
-	virtual void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
-	                                        const BlockType&  block,
-	                                        RealType          time) const
+	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
+	                                const BlockType&  block,
+	                                RealType          time) const override
 	{
 		extendedHubbard_.addDiagonalsInNaturalBasis(hmatrix, block, time);
 	}
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		const SizeType site = 0;
 		BlockType      block(1, site);
@@ -195,7 +195,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		extendedHubbard_.fillModelLinks();
 

--- a/dmrg/Models/SuperHubbardExtended/SuperHubbardExtended.h
+++ b/dmrg/Models/SuperHubbardExtended/SuperHubbardExtended.h
@@ -123,7 +123,7 @@ public:
 	    , extendedHubbard_(solverParams, io, geometry, "")
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -134,16 +134,16 @@ public:
 		extendedHubbard_.write(label, io);
 	}
 
-	virtual void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
-	                                        const BlockType&  block,
-	                                        RealType          time) const
+	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
+	                                const BlockType&  block,
+	                                RealType          time) const override
 	{
 		extendedHubbard_.addDiagonalsInNaturalBasis(hmatrix, block, time);
 	}
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		extendedHubbard_.fillLabeledOperators(qns);
 
@@ -151,7 +151,7 @@ protected:
 		this->makeTrackable("sz");
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		extendedHubbard_.fillModelLinks();
 

--- a/dmrg/Models/TjAncillaC/TjAncillaC.h
+++ b/dmrg/Models/TjAncillaC/TjAncillaC.h
@@ -139,7 +139,7 @@ public:
 			err("TjAncillaC:: cannot be run with Threads > 1 sorry\n");
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -149,7 +149,7 @@ public:
 		modelParameters_.write(label, io);
 	}
 
-	virtual PsimagLite::String oracle() const
+	PsimagLite::String oracle() const override
 	{
 		const RealType ne     = ModelBaseType::targetQuantum().qn(0).other[0];
 		const RealType n      = ModelBaseType::superGeometry().numberOfSites();
@@ -159,7 +159,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType               site = 0;
 		BlockType              block(1, site);
@@ -273,7 +273,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		//! There are orbitals*orbitals different orbitals
 		//! and 2 spins. Spin is diagonal so we end up with 2*orbitals*orbitals possiblities
@@ -545,7 +545,7 @@ private:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 

--- a/dmrg/Models/TjAncillaC2/TjAncillaC2.h
+++ b/dmrg/Models/TjAncillaC2/TjAncillaC2.h
@@ -137,7 +137,7 @@ public:
 	    , hot_(superGeometry_.geometry().term(0).orbitals(0) > 1)
 	{ }
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -148,7 +148,7 @@ public:
 		io.write(label + "/hot_", hot_);
 	}
 
-	virtual PsimagLite::String oracle() const
+	PsimagLite::String oracle() const override
 	{
 		const RealType ne     = ModelBaseType::targetQuantum().qn(0).other[0];
 		const RealType n      = ModelBaseType::superGeometry().numberOfSites();
@@ -158,7 +158,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType  site = 0;
 		BlockType block(1, site);
@@ -289,7 +289,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		//! There are orbitals*orbitals different orbitals
 		//! and 2 spins. Spin is diagonal so we end up with 2*orbitals*orbitals possiblities
@@ -554,7 +554,7 @@ private:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 

--- a/dmrg/Models/TjAncillaG/TjAncillaG.h
+++ b/dmrg/Models/TjAncillaG/TjAncillaG.h
@@ -148,7 +148,7 @@ public:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 
@@ -167,7 +167,7 @@ public:
 		}
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -183,7 +183,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType               site = 0;
 		BlockType              block(1, site);
@@ -302,7 +302,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		const bool isSu2 = BasisType::useSu2Symmetry();
 

--- a/dmrg/Models/TjAnisotropic/TjAnisotropic.h
+++ b/dmrg/Models/TjAnisotropic/TjAnisotropic.h
@@ -211,12 +211,12 @@ public:
 		return creationMatrix_[sigma].getCRS();
 	}
 
-	SizeType maxElectronsOneSpin() const
+	SizeType maxElectronsOneSpin() const override
 	{
 		return modelParameters_.orbitals * superGeometry_.numberOfSites() + 1;
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -234,7 +234,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType                        site = 0;
 		VectorSizeType                  block(1, site);
@@ -354,7 +354,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		OpForLinkType  sx("sx");
 		OpForLinkType  sy("sy");
@@ -611,7 +611,7 @@ private:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 

--- a/dmrg/Models/TjMultiOrb/TjMultiOrb.h
+++ b/dmrg/Models/TjMultiOrb/TjMultiOrb.h
@@ -204,12 +204,12 @@ public:
 		return creationMatrix_[3 * modelParameters_.orbitals + orb].getCRS();
 	}
 
-	SizeType maxElectronsOneSpin() const
+	SizeType maxElectronsOneSpin() const override
 	{
 		return modelParameters_.orbitals * superGeometry_.numberOfSites() + 1;
 	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -227,7 +227,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType               site = 0;
 		VectorSizeType         block(1, site);
@@ -377,7 +377,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		//! There are orbitals*orbitals different orbitals
 		//! and 2 spins. Spin is diagonal so we end up with 2*orbitals*orbitals possiblities
@@ -749,7 +749,7 @@ private:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 

--- a/dmrg/Models/UlsOsu/UlsOsu.h
+++ b/dmrg/Models/UlsOsu/UlsOsu.h
@@ -204,9 +204,12 @@ public:
 		return creationMatrix_[sigma].getCRS();
 	}
 
-	SizeType maxElectronsOneSpin() const { return 1 * superGeometry_.numberOfSites() + 1; }
+	SizeType maxElectronsOneSpin() const override
+	{
+		return 1 * superGeometry_.numberOfSites() + 1;
+	}
 
-	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const
+	void write(PsimagLite::String label1, PsimagLite::IoNg::Out::Serializer& io) const override
 	{
 		if (!io.doesGroupExist(label1))
 			io.createGroup(label1);
@@ -224,7 +227,7 @@ public:
 
 protected:
 
-	void fillLabeledOperators(VectorQnType& qns)
+	void fillLabeledOperators(VectorQnType& qns) override
 	{
 		SizeType                        site = 0;
 		VectorSizeType                  block(1, site);
@@ -307,7 +310,7 @@ protected:
 		}
 	}
 
-	void fillModelLinks()
+	void fillModelLinks() override
 	{
 		OpForLinkType sx("sx");
 		OpForLinkType sy("sy");
@@ -392,7 +395,7 @@ private:
 
 	void addDiagonalsInNaturalBasis(SparseMatrixType& hmatrix,
 	                                const BlockType&  block,
-	                                RealType          time) const
+	                                RealType          time) const override
 	{
 		ModelBaseType::additionalOnSiteHamiltonian(hmatrix, block, time);
 


### PR DESCRIPTION
I had this branch sitting around for awhile and couldn't quite decide if we want to add some clang-tidy checks.
Trying to understand what all the virtual function calls are, it seemed to make sense to ask `clang-tidy` to add `override` where appropriate.