### PR TITLE
Fix compiling with clang++-23

### DIFF
--- a/PsimagLite/src/PsimagLite/Concurrency.h
+++ b/PsimagLite/src/PsimagLite/Concurrency.h
@@ -87,6 +87,10 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#ifdef USE_PTHREADS
+#include <pthread.h>
+#endif
+
 namespace PsimagLite {
 
 class Concurrency {
@@ -114,8 +118,6 @@ public:
 	static PthreadtType threadSelf() { return 0; }
 
 #else
-
-#include <pthread.h>
 
 	using MutexType    = pthread_mutex_t;
 	using PthreadtType = pthread_t;

--- a/PsimagLite/src/PsimagLite/InputCheckBase.h
+++ b/PsimagLite/src/PsimagLite/InputCheckBase.h
@@ -78,6 +78,7 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #ifndef PSI_INPUTCHECK_BASE_H
 #define PSI_INPUTCHECK_BASE_H
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace PsimagLite {


### PR DESCRIPTION
Including `pthread.h` in the middle of a class caused very strange compiler errors. Also a `string` include was missing.