### PR TITLE
Remove unused USE_PTHREADS_OR_NOT_NG

### DIFF
--- a/LanczosPlusPlus/src/Engine/LanczosDriver.h
+++ b/LanczosPlusPlus/src/Engine/LanczosDriver.h
@@ -1,13 +1,6 @@
 #ifndef LANCZOSDRIVER_H
 #define LANCZOSDRIVER_H
 #include "../Version.h"
-#include <PsimagLite/AllocatorCpu.h>
-#include <PsimagLite/PsimagLite.h>
-#include <PsimagLite/Version.h>
-#include <cstdlib>
-#include <getopt.h>
-#include <unistd.h>
-#define USE_PTHREADS_OR_NOT_NG
 #include "DefaultSymmetry.h"
 #include "Engine.h"
 #include "InputCheck.h"
@@ -19,11 +12,17 @@
 #include "ReducedDensityMatrix.h"
 #include "ReflectionSymmetry.h"
 #include "TranslationSymmetry.h"
+#include <PsimagLite/AllocatorCpu.h>
 #include <PsimagLite/Concurrency.h>
 #include <PsimagLite/ContinuedFraction.h> // in PsimagLite
 #include <PsimagLite/ContinuedFractionCollection.h> // in PsimagLite
 #include <PsimagLite/Geometry/Geometry.h>
 #include <PsimagLite/InputNg.h> // in PsimagLite
+#include <PsimagLite/PsimagLite.h>
+#include <PsimagLite/Version.h>
+#include <cstdlib>
+#include <getopt.h>
+#include <unistd.h>
 
 #ifndef USE_FLOAT
 typedef double RealType;

--- a/PsimagLite/examples/affinityTest.cpp
+++ b/PsimagLite/examples/affinityTest.cpp
@@ -16,10 +16,9 @@ Please see full open source license included in file LICENSE.
 
 */
 #include <PsimagLite/Concurrency.h>
+#include <PsimagLite/Parallelizer.h>
 #include <cstdlib>
 #include <iostream>
-#define USE_PTHREADS_OR_NOT_NG
-#include <PsimagLite/Parallelizer.h>
 
 class MyHelper {
 

--- a/PsimagLite/examples/isBlasThreaded.cpp
+++ b/PsimagLite/examples/isBlasThreaded.cpp
@@ -1,9 +1,8 @@
 #include <PsimagLite/BLAS.h>
 #include <PsimagLite/Matrix.h>
+#include <PsimagLite/Parallelizer.h>
 #include <PsimagLite/Random48.h>
 #include <cstdlib> // for atoi
-#define USE_PTHREADS_OR_NOT_NG
-#include <PsimagLite/Parallelizer.h>
 
 typedef double                         MyRealType;
 typedef PsimagLite::Matrix<MyRealType> MatrixType;

--- a/PsimagLite/examples/loadImbalance.cpp
+++ b/PsimagLite/examples/loadImbalance.cpp
@@ -16,7 +16,6 @@ Please see full open source license included in file LICENSE.
 
 */
 #include <PsimagLite/Concurrency.h>
-#define USE_PTHREADS_OR_NOT_NG
 #include <PsimagLite/LoadBalancerWeights.h>
 #include <PsimagLite/Parallelizer.h>
 

--- a/PsimagLite/examples/nested.cpp
+++ b/PsimagLite/examples/nested.cpp
@@ -16,7 +16,6 @@ Please see full open source license included in file LICENSE.
 
 */
 #include <PsimagLite/Concurrency.h>
-#define USE_PTHREADS_OR_NOT_NG
 #include <PsimagLite/Parallelizer.h>
 
 #include <cstdlib>

--- a/PsimagLite/examples/range.cpp
+++ b/PsimagLite/examples/range.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#define USE_PTHREADS_OR_NOT_NG
 #include <PsimagLite/Concurrency.h>
 #include <PsimagLite/Parallelizer.h>
 

--- a/PsimagLite/examples/threads.cpp
+++ b/PsimagLite/examples/threads.cpp
@@ -16,7 +16,6 @@ Please see full open source license included in file LICENSE.
 
 */
 #include <PsimagLite/Concurrency.h>
-#define USE_PTHREADS_OR_NOT_NG
 #include <PsimagLite/Parallelizer.h>
 
 #include <cstdlib>

--- a/dmrg/Engine/Introspect.hh
+++ b/dmrg/Engine/Introspect.hh
@@ -1,6 +1,5 @@
 #ifndef DMRG_INTROSPECT_H
 #define DMRG_INTROSPECT_H
-#define USE_PTHREADS_OR_NOT_NG
 #include "OperatorSpec.h"
 #include "OptionsForIntrospect.hh"
 #include <PsimagLite/CanonicalExpression.h>

--- a/dmrg/Engine/QnHash.h
+++ b/dmrg/Engine/QnHash.h
@@ -1,6 +1,5 @@
 #ifndef DMRG_QN_HASH_H
 #define DMRG_QN_HASH_H
-#define USE_PTHREADS_OR_NOT_NG
 #include "Array.h"
 #include "Qn.h"
 #include <PsimagLite/Concurrency.h>

--- a/dmrg/ObserveDriver.h
+++ b/dmrg/ObserveDriver.h
@@ -1,8 +1,6 @@
 #ifndef OBSERVEDRIVER_H
 #define OBSERVEDRIVER_H
 
-#include <unistd.h>
-#define USE_PTHREADS_OR_NOT_NG
 #include "BasisWithOperators.h"
 #include "DmrgSolver.h" // only used for types
 #include "InputCheck.h"
@@ -27,6 +25,7 @@
 #include <PsimagLite/Geometry/Geometry.h>
 #include <PsimagLite/InputNg.h>
 #include <PsimagLite/Io/IoSelector.h>
+#include <unistd.h>
 
 namespace Dmrg {
 


### PR DESCRIPTION
This macro is unused since ba4c43c473116c8babd4f4c114dadb4b808aa233.
```
$ git grep -n "USE_PTHREADS_OR_NOT_NG" ..
../LanczosPlusPlus/src/Engine/LanczosDriver.h:10:#define USE_PTHREADS_OR_NOT_NG
../PsimagLite/examples/affinityTest.cpp:21:#define USE_PTHREADS_OR_NOT_NG
../PsimagLite/examples/isBlasThreaded.cpp:5:#define USE_PTHREADS_OR_NOT_NG
../PsimagLite/examples/loadImbalance.cpp:19:#define USE_PTHREADS_OR_NOT_NG
../PsimagLite/examples/nested.cpp:19:#define USE_PTHREADS_OR_NOT_NG
../PsimagLite/examples/range.cpp:25:#define USE_PTHREADS_OR_NOT_NG
../PsimagLite/examples/threads.cpp:19:#define USE_PTHREADS_OR_NOT_NG
../dmrg/Engine/Introspect.hh:3:#define USE_PTHREADS_OR_NOT_NG
../dmrg/Engine/QnHash.h:3:#define USE_PTHREADS_OR_NOT_NG
../dmrg/ObserveDriver.h:5:#define USE_PTHREADS_OR_NOT_NG
```